### PR TITLE
[Auth] 회원 가입 이메일 검증 시 탈퇴한 이메일도 같이 조회하도록 수정

### DIFF
--- a/src/main/java/com/sns/api/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sns/api/auth/service/impl/AuthServiceImpl.java
@@ -27,7 +27,7 @@ public class AuthServiceImpl implements AuthService {
     public UsersResponseDto signup(SignupRequestDto dto) {
         String email = dto.getEmail();
 
-        Optional<Users> userOpt = usersRepository.findByEmail(email); // 이메일 존재 여부 조회
+        Optional<Users> userOpt = usersRepository.findByEmailIncludeDeleted(email); // 이메일 존재 여부 조회
         if (userOpt.isPresent()) {
             throw new CustomException(ResultCode.VALID_FAIL, "이미 사용 중인 이메일입니다.");
         }

--- a/src/main/java/com/sns/api/users/repository/UsersRepository.java
+++ b/src/main/java/com/sns/api/users/repository/UsersRepository.java
@@ -2,9 +2,14 @@ package com.sns.api.users.repository;
 
 import com.sns.api.users.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
+
+    @Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
+    Optional<Users> findByEmailIncludeDeleted(@Param("email") String email);
 }


### PR DESCRIPTION
## Description
- 회원 가입 시 Email 검증할 때 탈퇴한 회원의 Email 까지 같이 검증

## Changes
- UsersRepository 에 findEmail 에서 삭제 한 회원 까지 검색 기능 추가
- AuthService singup 에서 활용
