### PR TITLE
뉴스피드 게시물 CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 src/main/resources/config/jm/
+
+## ncookie
+src/main/resources/config/ncookie
+db/mysql/data
+docker-compose.yml

--- a/src/main/java/com/sns/api/posts/controller/PostsController.java
+++ b/src/main/java/com/sns/api/posts/controller/PostsController.java
@@ -1,4 +1,74 @@
 package com.sns.api.posts.controller;
 
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
+import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
+import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.service.PostsService;
+import com.sns.common.component.BaseResponse;
+import com.sns.common.component.Const;
+import com.sns.common.component.ResultCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
 public class PostsController {
+
+    private final PostsService postsService;
+
+    @PostMapping
+    public BaseResponse<PostResponseDto> createPost(@RequestBody @Valid PostCreateRequestDto createRequestDto) {
+
+        PostResponseDto savedPost = postsService.createPost(createRequestDto);
+
+        return BaseResponse.success(savedPost, ResultCode.CREATED);
+    }
+
+    @GetMapping("/{postId}")
+    public BaseResponse<PostResponseDto> getPost(@PathVariable Long postId) {
+
+        PostResponseDto post = postsService.getPostById(postId);
+
+        return BaseResponse.success(post, ResultCode.OK);
+    }
+
+    @GetMapping
+    public BaseResponse<Page<PostResponseDto>> getPosts(
+            @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        Page<PostResponseDto> posts = postsService.getPosts(pageable);
+
+        return BaseResponse.success(posts, ResultCode.OK);
+    }
+
+    @PutMapping("/{postId}")
+    public BaseResponse<PostResponseDto> getPost(
+            @SessionAttribute(name = Const.LOGIN_USER) UserBaseDto userBaseDto,
+            @PathVariable Long postId,
+            @RequestBody @Valid PostUpdateRequestDto updateRequestDto
+    ) {
+
+        PostResponseDto updatedPost = postsService.updatePost(userBaseDto, postId, updateRequestDto);
+
+        return BaseResponse.success(updatedPost, ResultCode.OK);
+    }
+
+    @DeleteMapping("/{postId}")
+    public BaseResponse<Void> getPost(
+            @SessionAttribute(name = Const.LOGIN_USER) UserBaseDto userBaseDto,
+            @PathVariable Long postId
+    ) {
+
+        postsService.deletePost(userBaseDto, postId);
+
+        return BaseResponse.success(null, ResultCode.OK);
+    }
 }

--- a/src/main/java/com/sns/api/posts/domain/dto/PostsDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/PostsDto.java
@@ -1,4 +1,0 @@
-package com.sns.api.posts.domain.dto;
-
-public class PostsDto {
-}

--- a/src/main/java/com/sns/api/posts/domain/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/request/PostCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.sns.api.posts.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PostCreateRequestDto {
+
+    @NotBlank
+    @Size(max = 500)
+    private String content;
+
+}

--- a/src/main/java/com/sns/api/posts/domain/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/request/PostUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.sns.api.posts.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PostUpdateRequestDto {
+
+    @NotBlank
+    @Size(max = 500)
+    private String content;
+
+}

--- a/src/main/java/com/sns/api/posts/domain/dto/response/PostResponseDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/response/PostResponseDto.java
@@ -1,0 +1,32 @@
+package com.sns.api.posts.domain.dto.response;
+
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.entity.Posts;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostResponseDto {
+
+    private Long postId;                // 게시물 ID
+    private UserBaseDto createdBy;      // 작성자 정보
+
+    private String content;             // 본문
+
+    private LocalDateTime createdAt;    // 생성일
+    private LocalDateTime modifiedAt;   // 수정일
+
+    public static PostResponseDto fromEntity(Posts entity) {
+        return new PostResponseDto(
+                entity.getId(),
+                UserBaseDto.fromEntity(entity.getCreatedBy()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+
+}

--- a/src/main/java/com/sns/api/posts/domain/entity/Posts.java
+++ b/src/main/java/com/sns/api/posts/domain/entity/Posts.java
@@ -1,4 +1,44 @@
 package com.sns.api.posts.domain.entity;
 
-public class Posts {
+import com.sns.api.common.domain.entity.BaseUserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE posts SET is_deleted = true WHERE id = ?")     // soft delete 적용
+public class Posts extends BaseUserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;        // PK
+
+    @Column(nullable = false)
+    private String content;     // 게시물 본문
+
+    @Column(nullable = false)
+    private Boolean isDeleted;  // 삭제 여부
+
+    public static Posts of(String content) {
+        return new Posts(content);
+    }
+
+    public Posts(String content) {
+        this.content = content;
+
+        this.isDeleted = false;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/sns/api/posts/repository/PostsRepository.java
+++ b/src/main/java/com/sns/api/posts/repository/PostsRepository.java
@@ -1,4 +1,7 @@
 package com.sns.api.posts.repository;
 
-public interface PostsRepository {
+import com.sns.api.posts.domain.entity.Posts;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostsRepository extends JpaRepository<Posts, Long> {
 }

--- a/src/main/java/com/sns/api/posts/service/PostsService.java
+++ b/src/main/java/com/sns/api/posts/service/PostsService.java
@@ -1,4 +1,22 @@
 package com.sns.api.posts.service;
 
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
+import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
+import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface PostsService {
+
+    PostResponseDto createPost(PostCreateRequestDto createRequestDto);
+
+    PostResponseDto getPostById(Long postId);
+
+    Page<PostResponseDto> getPosts(Pageable pageable);
+
+    PostResponseDto updatePost(UserBaseDto userBaseDto, Long postId, PostUpdateRequestDto updateRequestDto);
+
+    void deletePost(UserBaseDto userBaseDto, Long postId);
+
 }

--- a/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
+++ b/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
@@ -1,4 +1,115 @@
 package com.sns.api.posts.service.impl;
 
-public class PostsServiceImpl {
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
+import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
+import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.domain.entity.Posts;
+import com.sns.api.posts.repository.PostsRepository;
+import com.sns.api.posts.service.PostsService;
+import com.sns.api.users.domain.entity.Users;
+import com.sns.api.users.repository.UsersRepository;
+import com.sns.common.component.ResultCode;
+import com.sns.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class PostsServiceImpl implements PostsService {
+
+    private final PostsRepository postsRepository;
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    @Override
+    public PostResponseDto createPost(PostCreateRequestDto createRequestDto) {
+
+        Posts savedPost = postsRepository.save(
+                Posts.of(
+                        createRequestDto.getContent()
+                )
+        );
+
+        return PostResponseDto.fromEntity(savedPost);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PostResponseDto getPostById(Long postId) {
+
+        Posts post = getPostByIdOrElseThrow(postId);
+
+        return PostResponseDto.fromEntity(post);
+    }
+
+    /**
+     * 기본 정렬은 생성일자 기준으로 내림차순 정렬
+     * 10개씩 페이지네이션
+     * @param pageable 페이징 정보
+     * @return Page 객체
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public Page<PostResponseDto> getPosts(Pageable pageable) {
+
+        return postsRepository.findAll(pageable).map(PostResponseDto::fromEntity);
+    }
+
+    @Transactional
+    @Override
+    public PostResponseDto updatePost(UserBaseDto userBaseDto, Long postId, PostUpdateRequestDto updateRequestDto) {
+
+        Users user = getUserByIdOrElseThrow(userBaseDto.getUserId());
+        Posts post = getPostByIdOrElseThrow(postId);
+
+        verifyOwnPost(user.getId(), post);
+
+        post.updateContent(updateRequestDto.getContent());
+
+        return PostResponseDto.fromEntity(post);
+    }
+
+    @Transactional
+    @Override
+    public void deletePost(UserBaseDto userBaseDto, Long postId) {
+
+        Users user = getUserByIdOrElseThrow(userBaseDto.getUserId());
+        Posts post = getPostByIdOrElseThrow(postId);
+
+        verifyOwnPost(user.getId(), post);
+
+        postsRepository.delete(post);
+    }
+
+
+    private Users getUserByIdOrElseThrow(Long userId) {
+
+        return usersRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "존재하지 않는 회원 ID 입니다: " + userId));
+    }
+
+    private Posts getPostByIdOrElseThrow(Long postId) {
+
+        return postsRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "존재하지 않는 게시글 ID 입니다.: " + postId));
+    }
+
+    /**
+     * 수정, 삭제하려는 회원이 게시물을 작성한 회원과 동일한지 검증하는 메서드
+     * @param userId 수정, 삭제를 요청한 회원의 ID
+     * @param post 대상 게시물
+     */
+    private void verifyOwnPost(Long userId, Posts post) {
+
+        if (!Objects.equals(userId, post.getCreatedBy().getId())) {
+            throw new CustomException(ResultCode.ACCESS_DENIED, "게시물의 수정, 삭제는 해당 게시물을 작성한 회원만 가능합니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/sns/common/config/PagingConfig.java
+++ b/src/main/java/com/sns/common/config/PagingConfig.java
@@ -1,0 +1,16 @@
+package com.sns.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+
+@Configuration
+public class PagingConfig {
+
+    // 클라이언트가 /posts?page=1이라고 보내면 스프링 내부적으로 page=0으로 바꿔줌
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer customizePageable() {
+        return resolver -> resolver.setOneIndexedParameters(true);
+    }
+
+}


### PR DESCRIPTION
## Description
- 게시물 도메인의 기본적인 CRUD 구현
- 게시물 전체 조회 구현
  - 클라이언트에서 요청 시 size, page, sort 등을 지정할 수 있다.
  - 페이징 조회 시 클라이언트가 보낸 페이지에서 1을 빼기 위해 PagingConfig 생성 (클라이언트는 페이지를 1부터, 서버는 0부터 인식하기 때문)
  - ex) `/api/posts?sort=createdAt,desc&size=10&page=1`

## Ref
- #13 
