### PR TITLE
[Friends] 친구 요청 수락/거절/취소 API 개발 및 친구 요청 API 방어로직 추가

### DIFF
--- a/src/main/java/com/sns/api/friends/controller/FriendsController.java
+++ b/src/main/java/com/sns/api/friends/controller/FriendsController.java
@@ -1,8 +1,9 @@
 package com.sns.api.friends.controller;
 
 import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
-import com.sns.api.friends.domain.dto.response.SendFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
 import com.sns.api.friends.service.FriendsService;
 import com.sns.common.component.BaseResponse;
 import com.sns.common.component.Const;
@@ -18,9 +19,37 @@ public class FriendsController {
 
     private final FriendsService friendsService;
 
+    /**
+     * 친구 요청 API
+     *
+     * @param requestDto 요청 받은 UserId
+     * @param userBaseDto 요청 한 User Id
+     * @return 성공 시 DTO 및 201 응답
+     */
     @PostMapping("/requests")
-    public BaseResponse<SendFriendsResponseDto> requestFriend(@RequestBody @Valid SendFriendsRequestDto requestDto,
-                                                              @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
+    public BaseResponse<CommonFriendsResponseDto> requestFriend(@RequestBody @Valid SendFriendsRequestDto requestDto,
+                                                                @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
         return BaseResponse.success(friendsService.requestFriend(requestDto, userBaseDto), ResultCode.CREATED);
+    }
+
+    /**
+     * 친구 요청 수락/거절/취소 API
+     *
+     * @param requestId 요청한 Friends 테이블의 PK 값
+     * @param requestDto 요청 상태값
+     * @param userBaseDto 로그인 유저 정보
+     * @return 수락 시 응답 DTO 및 200 응답, 거절, 취소 시 null 및 204 응답
+     */
+    @PutMapping("/requests/{requestId}")
+    public BaseResponse<CommonFriendsResponseDto> actionFriend(@PathVariable Long requestId,
+                                                               @RequestBody @Valid ActionFriendsRequestDto requestDto,
+                                                               @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
+
+        CommonFriendsResponseDto CommonFriendsResponseDto = friendsService.actionFriend(requestId, requestDto, userBaseDto);
+        if (CommonFriendsResponseDto == null) {
+            return BaseResponse.success(null, ResultCode.NO_CONTENT);
+        }
+
+        return BaseResponse.success(CommonFriendsResponseDto, ResultCode.OK);
     }
 }

--- a/src/main/java/com/sns/api/friends/controller/FriendsController.java
+++ b/src/main/java/com/sns/api/friends/controller/FriendsController.java
@@ -45,11 +45,11 @@ public class FriendsController {
                                                                @RequestBody @Valid ActionFriendsRequestDto requestDto,
                                                                @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
 
-        CommonFriendsResponseDto CommonFriendsResponseDto = friendsService.actionFriend(requestId, requestDto, userBaseDto);
-        if (CommonFriendsResponseDto == null) {
+        CommonFriendsResponseDto commonFriendsResponseDto = friendsService.actionFriend(requestId, requestDto, userBaseDto);
+        if (commonFriendsResponseDto == null) {
             return BaseResponse.success(null, ResultCode.NO_CONTENT);
         }
 
-        return BaseResponse.success(CommonFriendsResponseDto, ResultCode.OK);
+        return BaseResponse.success(commonFriendsResponseDto, ResultCode.OK);
     }
 }

--- a/src/main/java/com/sns/api/friends/domain/dto/request/ActionFriendsRequestDto.java
+++ b/src/main/java/com/sns/api/friends/domain/dto/request/ActionFriendsRequestDto.java
@@ -1,0 +1,14 @@
+package com.sns.api.friends.domain.dto.request;
+
+import com.sns.api.friends.domain.entity.FriendsStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ActionFriendsRequestDto {
+
+    @NotNull(message = "status는 필수값 입니다.")
+    private final FriendsStatus status;
+}

--- a/src/main/java/com/sns/api/friends/domain/dto/response/CommonFriendsResponseDto.java
+++ b/src/main/java/com/sns/api/friends/domain/dto/response/CommonFriendsResponseDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class SendFriendsResponseDto {
+public class CommonFriendsResponseDto {
 
     private final Long requestId;
     private final UserBaseDto sender;
@@ -19,8 +19,8 @@ public class SendFriendsResponseDto {
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
 
-    public static SendFriendsResponseDto toMapDto(Friends friends) {
-        return new SendFriendsResponseDto(
+    public static CommonFriendsResponseDto toMapDto(Friends friends) {
+        return new CommonFriendsResponseDto(
                 friends.getId(),
                 UserBaseDto.fromEntity(friends.getFromUser()),
                 UserBaseDto.fromEntity(friends.getToUser()),

--- a/src/main/java/com/sns/api/friends/domain/entity/Friends.java
+++ b/src/main/java/com/sns/api/friends/domain/entity/Friends.java
@@ -31,11 +31,15 @@ public class Friends extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private FriendsStatus status;
 
+    public void accept() {
+        this.status = FriendsStatus.ACCEPT;
+    }
+
     public static Friends of(Users SendUser, Users ReceiveUser) {
         return Friends.builder()
                 .fromUser(SendUser)
                 .toUser(ReceiveUser)
-                .status(FriendsStatus.ACCEPT).build();
+                .status(FriendsStatus.PENDING).build();
     }
 
 }

--- a/src/main/java/com/sns/api/friends/domain/entity/FriendsStatus.java
+++ b/src/main/java/com/sns/api/friends/domain/entity/FriendsStatus.java
@@ -1,6 +1,11 @@
 package com.sns.api.friends.domain.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum FriendsStatus {
     ACCEPT,
     PENDING,
+    REFUSAL,
+    CANCEL,
 }

--- a/src/main/java/com/sns/api/friends/domain/entity/FriendsStatus.java
+++ b/src/main/java/com/sns/api/friends/domain/entity/FriendsStatus.java
@@ -2,10 +2,13 @@ package com.sns.api.friends.domain.entity;
 
 import lombok.Getter;
 
+/**
+ * REFUSAL, CANCEL도 softdelete 해야 한다면 변경 가능
+ */
 @Getter
 public enum FriendsStatus {
-    ACCEPT,
-    PENDING,
-    REFUSAL,
-    CANCEL,
+    ACCEPT,     // 친구 수락(등록 완료)
+    PENDING,    // 친구 요청 대기 중
+    REFUSAL,    // 친구 요청 거절 -> DB에서 삭제
+    CANCEL,     // 친구 요청 취소 -> DB에서 삭제
 }

--- a/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
+++ b/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
@@ -1,6 +1,7 @@
 package com.sns.api.friends.repository;
 
 import com.sns.api.friends.domain.entity.Friends;
+import com.sns.api.users.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendsRepository extends JpaRepository<Friends, Long> {

--- a/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
+++ b/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
@@ -5,4 +5,5 @@ import com.sns.api.users.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendsRepository extends JpaRepository<Friends, Long> {
+    boolean existsByFromUserAndToUser(Users findSendUser, Users findReceiveUser);
 }

--- a/src/main/java/com/sns/api/friends/service/FriendsService.java
+++ b/src/main/java/com/sns/api/friends/service/FriendsService.java
@@ -1,9 +1,13 @@
 package com.sns.api.friends.service;
 
 import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
-import com.sns.api.friends.domain.dto.response.SendFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
+import jakarta.validation.Valid;
 
 public interface FriendsService {
-    SendFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto);
+    CommonFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto);
+
+    CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto);
 }

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -68,7 +68,7 @@ public class FriendsServiceImpl implements FriendsService {
         Long senderId = findFriends.getFromUser().getId();
         Long receiverId = findFriends.getToUser().getId();
 
-        if (!loginUserId.equals(senderId) || !loginUserId.equals(receiverId)) {
+        if (!loginUserId.equals(senderId) && !loginUserId.equals(receiverId)) {
             throw new CustomException(ResultCode.ACCESS_DENIED, "접근 권한이 없습니다.");
         }
 
@@ -78,7 +78,6 @@ public class FriendsServiceImpl implements FriendsService {
 
         return actionFriendStatus(requestDto, findFriends);
     }
-
 
     /**
      * SendUser, ReceiveUser 찾고 못찾으면 예외 던지는 메서드

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -1,9 +1,11 @@
 package com.sns.api.friends.service.impl;
 
 import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
-import com.sns.api.friends.domain.dto.response.SendFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
 import com.sns.api.friends.domain.entity.Friends;
+import com.sns.api.friends.domain.entity.FriendsStatus;
 import com.sns.api.friends.repository.FriendsRepository;
 import com.sns.api.friends.service.FriendsService;
 import com.sns.api.users.domain.entity.Users;
@@ -31,24 +33,88 @@ public class FriendsServiceImpl implements FriendsService {
      */
     @Override
     @Transactional
-    public SendFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto) {
+    public CommonFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto) {
 
         Users findReceiveUser = findUserByIdOrElseThrow(requestDto.getReceiverId());
         Users findSendUser = findUserByIdOrElseThrow(userBaseDto.getUserId());
 
+        // todo: 이미 보낸 친구 요청 방어 로직 추가해야 함
+
         Friends saveFriend = friendsRepository.save(Friends.of(findSendUser, findReceiveUser));
 
-        return SendFriendsResponseDto.toMapDto(saveFriend);
+        return CommonFriendsResponseDto.toMapDto(saveFriend);
     }
+
+    /**
+     * 친구 수락/거절/취소 처리
+     *
+     * @param friendsId 요청한 Friends 테이블의 PK 값
+     * @param requestDto 요청 상태값
+     * @param userBaseDto 로그인 유저 정보
+     * @return 수락 시 응답 DTO, 거절 및 취소 시 null 반환
+     */
+    @Override
+    @Transactional
+    public CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto) {
+
+        Friends findFriends = findFriendsByIdOrElseThrow(friendsId);
+
+        if (!findFriends.getToUser().getId().equals(userBaseDto.getUserId())) {
+            throw new CustomException(ResultCode.ACCESS_DENIED, "접근 권한이 없습니다.");
+        }
+
+        if (findFriends.getStatus() == FriendsStatus.ACCEPT) {
+            throw new CustomException(ResultCode.VALID_FAIL, "이미 수락된 친구입니다.");
+        }
+
+        return actionFriendStatus(requestDto, findFriends);
+    }
+
 
     /**
      * SendUser, ReceiveUser 찾고 못찾으면 예외 던지는 메서드
      *
      * @param userId 조회할 UserId
-     * @return 성공하면 User, 실패하면 NOT_FOUND 예외
+     * @return 성공하면 Users, 실패하면 NOT_FOUND 예외
      */
     private Users findUserByIdOrElseThrow(Long userId) {
         return usersRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    }
+
+    /**
+     * friend 찾고 못찾으면 예외 던지는 메서드
+     *
+     * @param friendsId 조회할 FriendsId
+     * @return 성공하면 Friends, 실패하면 NOT_FOUND
+     */
+    private Friends findFriendsByIdOrElseThrow(Long friendsId) {
+        return friendsRepository.findById(friendsId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "친구 요청 정보를 찾을 수 없습니다."));
+    }
+
+    /**
+     * 수락, 거절, 취소 상태에 따라 친구 요청 상태를 처리하는 메서드
+     * 요청 수락 -> ACCEPT 상태 반영 및 DTO 변환 후 반환
+     * 요청 거절, 취소 -> Friends 테이블에서 데이터 삭제 및 null 반환
+     * PENDING 및 잘못된 요청 시 400 예외 발생
+     *
+     * @param requestDto
+     * @param findFriends
+     * @return
+     */
+    private CommonFriendsResponseDto actionFriendStatus(ActionFriendsRequestDto requestDto, Friends findFriends) {
+        switch (requestDto.getStatus()) {
+            case ACCEPT -> {
+                findFriends.accept();
+                return CommonFriendsResponseDto.toMapDto(findFriends);
+            }
+            case CANCEL, REFUSAL -> {
+                friendsRepository.delete(findFriends);
+                return null;
+            }
+
+            default -> throw new CustomException(ResultCode.VALID_FAIL, "잘못된 요청값 입니다.");
+        }
     }
 }

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -38,6 +38,10 @@ public class FriendsServiceImpl implements FriendsService {
         Users findReceiveUser = findUserByIdOrElseThrow(requestDto.getReceiverId());
         Users findSendUser = findUserByIdOrElseThrow(userBaseDto.getUserId());
 
+        if (findReceiveUser.equals(findSendUser)) {
+            throw new CustomException(ResultCode.VALID_FAIL, "동일한 대상에게는 친구 요청을 할 수 없습니다.");
+        }
+
         if (friendsRepository.existsByFromUserAndToUser(findSendUser, findReceiveUser)) {
             throw new CustomException(ResultCode.VALID_FAIL, "이미 친구 요청을 보냈습니다.");
         }

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -38,7 +38,9 @@ public class FriendsServiceImpl implements FriendsService {
         Users findReceiveUser = findUserByIdOrElseThrow(requestDto.getReceiverId());
         Users findSendUser = findUserByIdOrElseThrow(userBaseDto.getUserId());
 
-        // todo: 이미 보낸 친구 요청 방어 로직 추가해야 함
+        if (friendsRepository.existsByFromUserAndToUser(findSendUser, findReceiveUser)) {
+            throw new CustomException(ResultCode.VALID_FAIL, "이미 친구 요청을 보냈습니다.");
+        }
 
         Friends saveFriend = friendsRepository.save(Friends.of(findSendUser, findReceiveUser));
 

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -60,8 +60,11 @@ public class FriendsServiceImpl implements FriendsService {
     public CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto) {
 
         Friends findFriends = findFriendsByIdOrElseThrow(friendsId);
+        Long loginUserId = userBaseDto.getUserId();
+        Long senderId = findFriends.getFromUser().getId();
+        Long receiverId = findFriends.getToUser().getId();
 
-        if (!findFriends.getToUser().getId().equals(userBaseDto.getUserId())) {
+        if (!loginUserId.equals(senderId) || !loginUserId.equals(receiverId)) {
             throw new CustomException(ResultCode.ACCESS_DENIED, "접근 권한이 없습니다.");
         }
 


### PR DESCRIPTION
## Description
- 친구 요청 수락/거절/취소 API 개발
    - 친구 요청 수락시 상태 ACCEPT 반영 및 DTO 반환, 200 응답 반환
    - 친구 요청 거절 및 취소 시 해당 친구 요청을 hard delete 진행 후 null 및 204 응답 반환(현재 애플리케이션에서는 해당 정보를 보관할 필요가 없다고 판단)
    - 친구 요청과,  친구 수락 시 응답하는 DTO가 동일하여 DTO명칭을 변경, SendFriendsResponseDto -> CommonFriendsResponseDto

- 친구 요청 방어로직 추가
    - 이미 보낸 친구 요청이 있을 경우 예외 발생

## Changes
- Friends Entity: accept 메서드 추가
- FriendsStatus: 상태 추가
- FriendsController, FrindeServiceImpl: API 및 비즈니스 로직 작성
- FriendsRepository: 친구 요청 방어로직을 위한 메서드 이름 쿼리 작성
- DTO: 요청 DTO 작성 및 응답 DTO 명칭 변경

## Screenshots
- 수락 성공
![image](https://github.com/user-attachments/assets/ec1a2b44-b07a-4a76-9e8a-eb06b378b2e5)



- 거절 성공
![image](https://github.com/user-attachments/assets/1b18e3cd-bd2d-4299-8146-948088acdec9)


- 취소 성공
![image](https://github.com/user-attachments/assets/073a9990-1c4b-4673-ba2b-e2b49a9b5d11)
