### PR TITLE
[Comments] 댓글 CRUD 구현

### DIFF
--- a/src/main/java/com/sns/api/comments/controller/CommentsController.java
+++ b/src/main/java/com/sns/api/comments/controller/CommentsController.java
@@ -1,4 +1,73 @@
 package com.sns.api.comments.controller;
 
+import com.sns.api.comments.domain.dto.request.CommentCreateRequestDto;
+import com.sns.api.comments.domain.dto.request.CommentUpdateRequestDto;
+import com.sns.api.comments.domain.dto.response.CommentResponseDto;
+import com.sns.api.comments.service.CommentsService;
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.common.component.BaseResponse;
+import com.sns.common.component.Const;
+import com.sns.common.component.ResultCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/comments")
+@RequiredArgsConstructor
 public class CommentsController {
+
+    private final CommentsService commentsService;
+
+    @PostMapping
+    public BaseResponse<CommentResponseDto> createComment(@PathVariable Long postId,
+                                                          @RequestBody @Valid CommentCreateRequestDto createRequestDto) {
+
+        CommentResponseDto savedComment = commentsService.createComment(postId, createRequestDto);
+
+        return BaseResponse.success(savedComment, ResultCode.CREATED);
+    }
+
+    @GetMapping("/{commentId}")
+    public BaseResponse<CommentResponseDto> getComment(@PathVariable Long postId, @PathVariable Long commentId) {
+
+        CommentResponseDto comment = commentsService.getCommentById(postId, commentId);
+
+        return BaseResponse.success(comment, ResultCode.OK);
+    }
+
+    @GetMapping
+    public BaseResponse<Page<CommentResponseDto>> getComments(@PathVariable Long postId,
+                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<CommentResponseDto> comments = commentsService.getCommentsByPost(pageable, postId);
+
+        return BaseResponse.success(comments, ResultCode.OK);
+    }
+
+    @PutMapping("/{commentId}")
+    public BaseResponse<CommentResponseDto> updateComment(@PathVariable Long postId,
+                                                          @PathVariable Long commentId,
+                                                          @RequestBody @Valid CommentUpdateRequestDto updateRequestDto,
+                                                          @SessionAttribute(name = Const.LOGIN_USER) UserBaseDto userBaseDto) {
+
+        CommentResponseDto updatedComment = commentsService.updateComment(postId, commentId, updateRequestDto, userBaseDto);
+
+        return BaseResponse.success(updatedComment, ResultCode.OK);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public BaseResponse<Void> deleteComment(@PathVariable Long postId,
+                                            @PathVariable Long commentId,
+                                            @SessionAttribute(name = Const.LOGIN_USER) UserBaseDto userBaseDto) {
+
+        commentsService.deleteComment(postId, commentId, userBaseDto);
+
+        return BaseResponse.success(null, ResultCode.OK);
+    }
+
 }

--- a/src/main/java/com/sns/api/comments/domain/dto/CommentsDto.java
+++ b/src/main/java/com/sns/api/comments/domain/dto/CommentsDto.java
@@ -1,4 +1,0 @@
-package com.sns.api.comments.domain.dto;
-
-public class CommentsDto {
-}

--- a/src/main/java/com/sns/api/comments/domain/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/com/sns/api/comments/domain/dto/request/CommentCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.sns.api.comments.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCreateRequestDto {
+
+    @NotBlank(message = "댓글 내용이 없습니다.")
+    @Size(max = 500, message = "댓글은 최대 500글자까지 입력 가능합니다.")
+    private String content;
+
+}

--- a/src/main/java/com/sns/api/comments/domain/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/com/sns/api/comments/domain/dto/request/CommentUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.sns.api.comments.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentUpdateRequestDto {
+
+    @NotBlank(message = "댓글 내용이 없습니다.")
+    @Size(max = 500, message = "댓글은 최대 500글자까지 입력 가능합니다.")
+    private String content;
+
+}

--- a/src/main/java/com/sns/api/comments/domain/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/sns/api/comments/domain/dto/response/CommentResponseDto.java
@@ -1,0 +1,36 @@
+package com.sns.api.comments.domain.dto.response;
+
+import com.sns.api.comments.domain.entity.Comments;
+import com.sns.api.common.domain.dto.UserBaseDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponseDto {
+
+    private Long commentId;             // 댓글 ID
+    private Long postId;                // 게시물 ID
+    private UserBaseDto createdBy;      // 작성자 정보
+    private UserBaseDto modifiedBy;     // 수정자 정보
+    
+    private String content;             // 본문
+
+    private LocalDateTime createdAt;    // 생성일
+    private LocalDateTime modifiedAt;   // 수정일
+
+    public static CommentResponseDto fromEntity(Comments entity) {
+        return new CommentResponseDto(
+                entity.getId(),
+                entity.getPost().getId(),
+                UserBaseDto.fromEntity(entity.getCreatedBy()),
+                UserBaseDto.fromEntity(entity.getModifiedBy()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+
+}

--- a/src/main/java/com/sns/api/comments/domain/entity/Comments.java
+++ b/src/main/java/com/sns/api/comments/domain/entity/Comments.java
@@ -1,4 +1,49 @@
 package com.sns.api.comments.domain.entity;
 
-public class Comments {
+import com.sns.api.common.domain.entity.BaseUserEntity;
+import com.sns.api.posts.domain.entity.Posts;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE comments SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+public class Comments extends BaseUserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;            // PK
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Posts post;         // 소속 게시물
+    
+    @Column(nullable = false)
+    private String content;     // 댓글 본문
+
+    @Column(nullable = false)
+    private Boolean isDeleted;  // 삭제 여부
+
+    public static Comments of(Posts post, String content) {
+        return new Comments(post, content);
+    }
+
+    public Comments(Posts post, String content) {
+        this.post = post;
+        this.content = content;
+        this.isDeleted = false;
+    }
+
+    public void updateComment(String content) {
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
@@ -1,4 +1,13 @@
 package com.sns.api.comments.repository;
 
-public interface CommentsRepository {
+import com.sns.api.comments.domain.entity.Comments;
+import com.sns.api.posts.domain.entity.Posts;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentsRepository extends JpaRepository<Comments, Long> {
+
+    Page<Comments> findAllByPost(Posts post, Pageable pageable);
+
 }

--- a/src/main/java/com/sns/api/comments/service/CommentsService.java
+++ b/src/main/java/com/sns/api/comments/service/CommentsService.java
@@ -1,4 +1,22 @@
 package com.sns.api.comments.service;
 
+import com.sns.api.comments.domain.dto.request.CommentCreateRequestDto;
+import com.sns.api.comments.domain.dto.request.CommentUpdateRequestDto;
+import com.sns.api.comments.domain.dto.response.CommentResponseDto;
+import com.sns.api.common.domain.dto.UserBaseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface CommentsService {
+
+    CommentResponseDto createComment(Long postId, CommentCreateRequestDto createRequestDto);
+
+    CommentResponseDto getCommentById(Long postId, Long commentId);
+
+    Page<CommentResponseDto> getCommentsByPost(Pageable pageable, Long postId);
+
+    CommentResponseDto updateComment(Long postId, Long commentId, CommentUpdateRequestDto updateRequestDto, UserBaseDto userBaseDto);
+
+    void deleteComment(Long postId, Long commentId, UserBaseDto userBaseDto);
+
 }

--- a/src/main/java/com/sns/api/comments/service/impl/CommentsServiceImpl.java
+++ b/src/main/java/com/sns/api/comments/service/impl/CommentsServiceImpl.java
@@ -58,8 +58,7 @@ public class CommentsServiceImpl implements CommentsService {
     @Override
     public Page<CommentResponseDto> getCommentsByPost(Pageable pageable, Long postId) {
 
-        Posts post = postsRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND));
+        Posts post = getPostByIdOrElseThrow(postId);
 
         Page<Comments> comments = commentsRepository.findAllByPost(post, pageable);
 

--- a/src/main/java/com/sns/api/comments/service/impl/CommentsServiceImpl.java
+++ b/src/main/java/com/sns/api/comments/service/impl/CommentsServiceImpl.java
@@ -1,6 +1,160 @@
 package com.sns.api.comments.service.impl;
 
+import com.sns.api.comments.domain.dto.request.CommentCreateRequestDto;
+import com.sns.api.comments.domain.dto.request.CommentUpdateRequestDto;
+import com.sns.api.comments.domain.dto.response.CommentResponseDto;
+import com.sns.api.comments.domain.entity.Comments;
+import com.sns.api.comments.repository.CommentsRepository;
 import com.sns.api.comments.service.CommentsService;
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.entity.Posts;
+import com.sns.api.posts.repository.PostsRepository;
+import com.sns.common.component.ResultCode;
+import com.sns.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
 public class CommentsServiceImpl implements CommentsService {
+
+    private final CommentsRepository commentsRepository;
+    private final PostsRepository postsRepository;
+
+    @Transactional
+    @Override
+    public CommentResponseDto createComment(Long postId, CommentCreateRequestDto createRequestDto) {
+
+        Posts post = getPostByIdOrElseThrow(postId);
+
+        Comments savedComment = commentsRepository.save(
+                Comments.of(
+                        post,
+                        createRequestDto.getContent()
+                )
+        );
+
+        return CommentResponseDto.fromEntity(savedComment);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CommentResponseDto getCommentById(Long postId, Long commentId) {
+
+        Comments comment = getCommentByIdOrElseThrow(commentId);
+
+        // 유효성 검사
+        validateCommentBelongsToPost(postId, comment);
+
+        return CommentResponseDto.fromEntity(comment);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<CommentResponseDto> getCommentsByPost(Pageable pageable, Long postId) {
+
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND));
+
+        Page<Comments> comments = commentsRepository.findAllByPost(post, pageable);
+
+        return comments.map(CommentResponseDto::fromEntity);
+    }
+
+    /**
+     * 댓글의 수정은 댓글의 작성자 혹은 게시글의 작성자만 가능
+     * @param userBaseDto 댓글 수정 요청 회원
+     * @param commentId 댓글 ID
+     * @param updateRequestDto 댓글 수정 내용
+     * @return 수정된 댓글 DTO
+     */
+    @Transactional
+    @Override
+    public CommentResponseDto updateComment(Long postId, Long commentId, CommentUpdateRequestDto updateRequestDto, UserBaseDto userBaseDto) {
+
+        Comments comment = getCommentByIdOrElseThrow(commentId);
+        
+        // 유효성 검사
+        validateCommentBelongsToPost(postId, comment);
+        validateUpdateOrDeleteAuthority(
+                userBaseDto.getUserId(),
+                comment.getPost().getCreatedBy().getId(),
+                comment.getCreatedBy().getId()
+        );
+
+        comment.updateComment(updateRequestDto.getContent());
+        
+        return CommentResponseDto.fromEntity(comment);
+    }
+
+    /**
+     * 댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능
+     * @param userBaseDto 댓글 삭제 요청 회원
+     * @param commentId 댓글 ID
+     */
+    @Transactional
+    @Override
+    public void deleteComment(Long postId, Long commentId, UserBaseDto userBaseDto) {
+
+        Comments comment = getCommentByIdOrElseThrow(commentId);
+
+        // 유효성 검사
+        validateCommentBelongsToPost(postId, comment);
+        validateUpdateOrDeleteAuthority(
+                userBaseDto.getUserId(),
+                comment.getPost().getCreatedBy().getId(),
+                comment.getCreatedBy().getId()
+        );
+
+        commentsRepository.delete(comment);
+    }
+
+
+    private Comments getCommentByIdOrElseThrow(Long commentId) {
+
+        return commentsRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "존재하지 않는 댓글 ID입니다: " + commentId));
+    }
+
+    private Posts getPostByIdOrElseThrow(Long postId) {
+
+        return postsRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "존재하지 않는 게시물 ID입니다: " + postId));
+    }
+
+    /**
+     * 댓글 수정, 삭제 시 댓글이 게시물에 속하는지 확인하는 메서드
+     * @param postId path variable 로 전달된 게시물 ID
+     * @param comment 댓글 entity
+     */
+    public void validateCommentBelongsToPost(Long postId, Comments comment) {
+
+        if (!Objects.equals(postId, comment.getPost().getId())) {
+            throw new CustomException(ResultCode.VALID_FAIL, "댓글은 해당 게시물에 속하지 않습니다.");
+        }
+    }
+
+    /**
+     * 댓글의 수정, 삭제를 요청한 회원에게 권한이 있는지 검사하고, 없다면 예외를 발생시키는 메서드
+     * 댓글 수정, 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능하다.
+     * @param userId 요청 회원 ID
+     * @param postWriterId 게시물 작성자 ID
+     * @param commentWriterId 댓글 작성자 ID
+     */
+    private void validateUpdateOrDeleteAuthority(Long userId, Long postWriterId, Long commentWriterId) {
+
+        boolean authorized = Objects.equals(userId, postWriterId) || Objects.equals(userId, commentWriterId);
+
+        // 수정, 삭제하려는 댓글의 작성자이거나, 게시글의 작성자이면 통과
+        if (!authorized) {
+            throw new CustomException(ResultCode.ACCESS_DENIED, "댓글의 수정, 삭제는 글의 작성자 혹은 게시글의 작성자만 가능합니다.");
+        }
+
+    }
+
 }


### PR DESCRIPTION
## Description
- 기본적인 CRUD 구현
- 댓글은 댓글 작성자 외에도 게시물 작성자가 수정, 삭제할 수 있으므로 응답 데이터로 `createdBy`, `modifiedBy` 모두 포함한다.
- 유효성 검사
  - 댓글 단건 조회, 수정, 삭제 시 댓글이 해당 게시물에 속하는지 검사한다.
  - 댓글 수정, 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능하다.

## Ref
#23 

This closes #23 
