### PR TITLE
[Friends]친구 삭제 API 개발 #29 

### DIFF
--- a/src/main/java/com/sns/api/friends/controller/FriendsController.java
+++ b/src/main/java/com/sns/api/friends/controller/FriendsController.java
@@ -22,7 +22,7 @@ public class FriendsController {
     /**
      * 친구 요청 API
      *
-     * @param requestDto 요청 받은 UserId
+     * @param requestDto  요청 받은 UserId
      * @param userBaseDto 요청 한 User Id
      * @return 성공 시 DTO 및 201 응답
      */
@@ -35,8 +35,8 @@ public class FriendsController {
     /**
      * 친구 요청 수락/거절/취소 API
      *
-     * @param requestId 요청한 Friends 테이블의 PK 값
-     * @param requestDto 요청 상태값
+     * @param requestId   요청한 Friends 테이블의 PK 값
+     * @param requestDto  요청 상태값
      * @param userBaseDto 로그인 유저 정보
      * @return 수락 시 응답 DTO 및 200 응답, 거절, 취소 시 null 및 204 응답
      */
@@ -52,4 +52,19 @@ public class FriendsController {
 
         return BaseResponse.success(commonFriendsResponseDto, ResultCode.OK);
     }
+
+    /**
+     * 친구 삭제 API(ACCEPT)
+     *
+     * @param requestId 삭제할 대상 PK
+     * @param userBaseDto 로그인한 유저
+     * @return 204 응답
+     */
+    @DeleteMapping("/{requestId}")
+    public BaseResponse<Void> deleteFriends(@PathVariable Long requestId,
+                                            @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
+        friendsService.deleteFriends(requestId, userBaseDto);
+        return BaseResponse.success(null, ResultCode.NO_CONTENT);
+    }
+
 }

--- a/src/main/java/com/sns/api/friends/service/FriendsService.java
+++ b/src/main/java/com/sns/api/friends/service/FriendsService.java
@@ -4,10 +4,11 @@ import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
 import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
-import jakarta.validation.Valid;
 
 public interface FriendsService {
     CommonFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto);
 
     CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto);
+
+    void deleteFriends(Long requestId, UserBaseDto userBaseDto);
 }

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -27,7 +27,7 @@ public class FriendsServiceImpl implements FriendsService {
     /**
      * 친구 요청 저장
      *
-     * @param requestDto 요청 받은 UserId
+     * @param requestDto  요청 받은 UserId
      * @param userBaseDto 요청 한 User Id
      * @return 응답 DTO
      */
@@ -54,8 +54,8 @@ public class FriendsServiceImpl implements FriendsService {
     /**
      * 친구 수락/거절/취소 처리
      *
-     * @param friendsId 요청한 Friends 테이블의 PK 값
-     * @param requestDto 요청 상태값
+     * @param friendsId   요청한 Friends 테이블의 PK 값
+     * @param requestDto  요청 상태값
      * @param userBaseDto 로그인 유저 정보
      * @return 수락 시 응답 DTO, 거절 및 취소 시 null 반환
      */
@@ -64,19 +64,33 @@ public class FriendsServiceImpl implements FriendsService {
     public CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto) {
 
         Friends findFriends = findFriendsByIdOrElseThrow(friendsId);
-        Long loginUserId = userBaseDto.getUserId();
-        Long senderId = findFriends.getFromUser().getId();
-        Long receiverId = findFriends.getToUser().getId();
-
-        if (!loginUserId.equals(senderId) && !loginUserId.equals(receiverId)) {
-            throw new CustomException(ResultCode.ACCESS_DENIED, "접근 권한이 없습니다.");
-        }
+        validateAccess(findFriends, userBaseDto);    // 권한 검증 메서드
 
         if (findFriends.getStatus() == FriendsStatus.ACCEPT) {
             throw new CustomException(ResultCode.VALID_FAIL, "이미 수락된 친구입니다.");
         }
 
         return actionFriendStatus(requestDto, findFriends);
+    }
+
+    /**
+     * 친구 삭제 처리
+     *
+     * @param requestId 요청한 Friends 테이블의 PK 값
+     * @param userBaseDto 로그인 유저 정보
+     */
+    @Override
+    @Transactional
+    public void deleteFriends(Long requestId, UserBaseDto userBaseDto) {
+
+        Friends findFriends = findFriendsByIdOrElseThrow(requestId);
+        validateAccess(findFriends, userBaseDto);    // 권한 검증 메서드
+
+        if (findFriends.getStatus() != FriendsStatus.ACCEPT) {  // 상태가 ACCEPT가 아니면 예외
+            throw new CustomException(ResultCode.VALID_FAIL, "잘못된 요청값 입니다.");
+        }
+
+        friendsRepository.delete(findFriends);
     }
 
     /**
@@ -107,9 +121,9 @@ public class FriendsServiceImpl implements FriendsService {
      * 요청 거절, 취소 -> Friends 테이블에서 데이터 삭제 및 null 반환
      * PENDING 및 잘못된 요청 시 400 예외 발생
      *
-     * @param requestDto
-     * @param findFriends
-     * @return
+     * @param requestDto 전달된 요청 값
+     * @param findFriends 찾은 Friends
+     * @return 응답할 DTO
      */
     private CommonFriendsResponseDto actionFriendStatus(ActionFriendsRequestDto requestDto, Friends findFriends) {
         switch (requestDto.getStatus()) {
@@ -121,8 +135,25 @@ public class FriendsServiceImpl implements FriendsService {
                 friendsRepository.delete(findFriends);
                 return null;
             }
-
             default -> throw new CustomException(ResultCode.VALID_FAIL, "잘못된 요청값 입니다.");
+        }
+    }
+
+    /**
+     * 로그인한 사용자가 조회된 friends의 fromUser, toUser에 포함되는지 검증하는 메서드
+     * 검증 실패 시 403 예외 발생
+     *
+     * @param findFriends 조회된 friends
+     * @param userBaseDto 로그인한 User 정보
+     */
+    private void validateAccess(Friends findFriends, UserBaseDto userBaseDto) {
+
+        Long loginUserId = userBaseDto.getUserId();
+        Long senderId = findFriends.getFromUser().getId();
+        Long receiverId = findFriends.getToUser().getId();
+
+        if (!loginUserId.equals(senderId) && !loginUserId.equals(receiverId)) {
+            throw new CustomException(ResultCode.ACCESS_DENIED, "접근 권한이 없습니다.");
         }
     }
 }


### PR DESCRIPTION
## Description
- 친구 삭제 API 개발
    - 삭제 성공시 204 응답
    - 삭제 실패 검증 로직 추가
        - 403: Friends 테이블의 from_user_id, to_user_id 에도 포함되지 않은 사용자가 요청할 때
        - 404: 삭제할 Friends가 없을 때
        - 403 검증 로직을 메서드화하여 재사용 하도록 하고 가독성을 높이도록 수정


## Changes
- FriendsController, FriendsService, FriendsServiceImpl 수정 발생

## Screenshots
- 권한 없음 실패(403, 친구가 아님)
![image](https://github.com/user-attachments/assets/a35f90ea-f1db-4c0b-bac5-80d78c00ee32)


- 삭제 성공
![image](https://github.com/user-attachments/assets/91e13f25-271d-4776-8462-397367a1090c)

## Ref
#29 
This closes #29 
