### PR TITLE
[Friends]내 친구 전체 조회 API 개발 #30 

### DIFF
--- a/src/main/java/com/sns/api/friends/controller/FriendsController.java
+++ b/src/main/java/com/sns/api/friends/controller/FriendsController.java
@@ -4,12 +4,16 @@ import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
 import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.FindFriendsResponseDto;
 import com.sns.api.friends.service.FriendsService;
 import com.sns.common.component.BaseResponse;
 import com.sns.common.component.Const;
 import com.sns.common.component.ResultCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,6 +22,19 @@ import org.springframework.web.bind.annotation.*;
 public class FriendsController {
 
     private final FriendsService friendsService;
+
+    /**
+     * 내 친구 전체 조회
+     *
+     * @param userBaseDto 로그인 유저 정보
+     * @param pageable 페이징 정보(기본 5개씩 출력)
+     * @return 조회된 친구 Page<DTO> 및 200 응답
+     */
+    @GetMapping("/me")
+    public BaseResponse<Page<FindFriendsResponseDto>> findAcceptFriends(@SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto,
+                                                                        @PageableDefault(size = 5) Pageable pageable) {
+        return BaseResponse.success(friendsService.findAcceptFriends(userBaseDto, pageable), ResultCode.OK);
+    }
 
     /**
      * 친구 요청 API

--- a/src/main/java/com/sns/api/friends/domain/dto/response/FindFriendsResponseDto.java
+++ b/src/main/java/com/sns/api/friends/domain/dto/response/FindFriendsResponseDto.java
@@ -1,0 +1,32 @@
+package com.sns.api.friends.domain.dto.response;
+
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.friends.domain.entity.Friends;
+import com.sns.api.friends.domain.entity.FriendsStatus;
+import com.sns.api.users.domain.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class FindFriendsResponseDto {
+
+    private final Long requestId;
+    private final UserBaseDto friend;
+    private final FriendsStatus status;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    public static FindFriendsResponseDto toMapDto(Friends friends, Users friend) {
+        return new FindFriendsResponseDto(
+                friends.getId(),
+                UserBaseDto.fromEntity(friend),
+                friends.getStatus(),
+                friends.getCreatedAt(),
+                friends.getModifiedAt()
+        );
+
+    }
+}

--- a/src/main/java/com/sns/api/friends/domain/entity/Friends.java
+++ b/src/main/java/com/sns/api/friends/domain/entity/Friends.java
@@ -8,7 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "frineds")
+// 실무에서는 직접 테이블을 만들 때 index를 적용하지만 local DB를 사용하고 실행 될 때마다 테이블을 다시 생성할 것이므로 index 설정을 추가
+@Table(name = "friends", indexes = {
+        @Index(name = "idx_from_user", columnList = "from_user_id"),
+        @Index(name = "idx_to_user", columnList = "to_user_id"),
+        @Index(name = "idx_status", columnList = "status")
+})
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
+++ b/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
@@ -2,8 +2,37 @@ package com.sns.api.friends.repository;
 
 import com.sns.api.friends.domain.entity.Friends;
 import com.sns.api.users.domain.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FriendsRepository extends JpaRepository<Friends, Long> {
     boolean existsByFromUserAndToUser(Users findSendUser, Users findReceiveUser);
+
+    /**
+     * 로그인 유저 Id를 기준으로 친구 데이터를 조회하는 쿼리
+     *
+     * 연관된 Entity인 fromUser, toUser를 한번에 가져오기 위한 @EntityGraph 사용(Page와 fetch join을 함께 사용하면 메모리에서 페이징 되기 때문에 위험함)
+     * where 조건: 접속한 유저를 기준으로 fromUser, toUser에 본인이 있을 수 있기 때문에 or 조건 지정
+     * and: 친구인 상태(ACCEPT)만 조회
+     * order by: 조회된 친구의 username 필드를 기준으로 오름차순 정렬하기 위한 case 문
+     *
+     * @param loginUserId 로그인 유저 Id
+     * @param pageable 페이징 정보
+     * @return 조회된 친구 데이터 반환(페이징 적용)
+     */
+    @EntityGraph(attributePaths = {"fromUser", "toUser"})
+    @Query("""
+        select f from Friends f
+        where (f.fromUser.id = :loginUserId or f.toUser.id = :loginUserId)
+            and f.status = 'ACCEPT'
+        order by case
+            when f.fromUser.id = :loginUserId then f.toUser.username
+            else f.fromUser.username
+            end 
+    """)
+    Page<Friends> findAcceptedFriendsByLoginUserId(@Param("loginUserId") Long loginUserId, Pageable pageable);
 }

--- a/src/main/java/com/sns/api/friends/service/FriendsService.java
+++ b/src/main/java/com/sns/api/friends/service/FriendsService.java
@@ -4,6 +4,9 @@ import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
 import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.FindFriendsResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FriendsService {
     CommonFriendsResponseDto requestFriend(SendFriendsRequestDto requestDto, UserBaseDto userBaseDto);
@@ -11,4 +14,6 @@ public interface FriendsService {
     CommonFriendsResponseDto actionFriend(Long friendsId, ActionFriendsRequestDto requestDto, UserBaseDto userBaseDto);
 
     void deleteFriends(Long requestId, UserBaseDto userBaseDto);
+
+    Page<FindFriendsResponseDto> findAcceptFriends(UserBaseDto userBaseDto, Pageable pageable);
 }

--- a/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
+++ b/src/main/java/com/sns/api/friends/service/impl/FriendsServiceImpl.java
@@ -4,6 +4,7 @@ import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.friends.domain.dto.request.ActionFriendsRequestDto;
 import com.sns.api.friends.domain.dto.request.SendFriendsRequestDto;
 import com.sns.api.friends.domain.dto.response.CommonFriendsResponseDto;
+import com.sns.api.friends.domain.dto.response.FindFriendsResponseDto;
 import com.sns.api.friends.domain.entity.Friends;
 import com.sns.api.friends.domain.entity.FriendsStatus;
 import com.sns.api.friends.repository.FriendsRepository;
@@ -13,6 +14,9 @@ import com.sns.api.users.repository.UsersRepository;
 import com.sns.common.component.ResultCode;
 import com.sns.common.exception.CustomException;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +27,34 @@ public class FriendsServiceImpl implements FriendsService {
 
     private final FriendsRepository friendsRepository;
     private final UsersRepository usersRepository;
+
+    /**
+     * 친구 조회 비즈니스 로직
+     * 조회된 Friends 정보들을 Dto로 변환할 때 내가 친구를 요청하거나, 친구 요청을 받았을 수 있으므로 동적으로 변환하여 처리
+     *
+     * @param userBaseDto 로그인 유저 정보
+     * @param pageable 페이징 정보
+     * @return 조회된 Page<DTO>
+     */
+    @Override
+    public Page<FindFriendsResponseDto> findAcceptFriends(UserBaseDto userBaseDto, Pageable pageable) {
+
+        Long loginUserId = userBaseDto.getUserId();
+
+        Page<FindFriendsResponseDto> findAcceptsFriends = friendsRepository.findAcceptedFriendsByLoginUserId(loginUserId, pageable)
+                .map(friends -> FindFriendsResponseDto.toMapDto(friends,
+                        friends.getFromUser().getId().equals(loginUserId)
+                                ? friends.getToUser()
+                                : friends.getFromUser())
+
+                );
+
+        if (findAcceptsFriends.isEmpty()) { // 조회된 정보가 없으면 예외처리
+            throw new CustomException(ResultCode.NOT_FOUND, "조회된 회원이 없습니다.");
+        }
+
+        return findAcceptsFriends;
+    }
 
     /**
      * 친구 요청 저장
@@ -76,7 +108,7 @@ public class FriendsServiceImpl implements FriendsService {
     /**
      * 친구 삭제 처리
      *
-     * @param requestId 요청한 Friends 테이블의 PK 값
+     * @param requestId   요청한 Friends 테이블의 PK 값
      * @param userBaseDto 로그인 유저 정보
      */
     @Override
@@ -121,7 +153,7 @@ public class FriendsServiceImpl implements FriendsService {
      * 요청 거절, 취소 -> Friends 테이블에서 데이터 삭제 및 null 반환
      * PENDING 및 잘못된 요청 시 400 예외 발생
      *
-     * @param requestDto 전달된 요청 값
+     * @param requestDto  전달된 요청 값
      * @param findFriends 찾은 Friends
      * @return 응답할 DTO
      */


### PR DESCRIPTION
## Description
- 내 친구 전체 조회 API 개발
    - 로그인 유저를 대상으로 Friends 테이블의 status 상태가 ACCEPT일 때 친구들을 전체 조회하도록 설정
    - 페이징 size는 5개씩 끊어서 출력하고 정렬은 친구의 이름을 오름차순하여 정렬
    - 조회가 성공하면 데이터와 200응답, 데이터를 못찾는다면 404 응답

## Changes
- Friends
    - ddl-auto: create로 개발하고 있기 때문에 자동으로 테이블 생성 시 Friends 테이블의 컬럼들인from_user_id와 to_user_id, stats에 인덱스를 지정하여 검색 조회 성능을 증가시키도록 적용


- FriendsRepository
    - @EntityGraph와 @Query를 통해 연관관계 컬럼을 한번에 조회하면서 페이징을 적용하며 n+1 문제도 동시에 해결

- 그 외
    - dto 생성
    - FriendsController, FirendsService 및 구현체에 관련 코드 작성

## Screenshots
- 내 친구 조회 성공
![image](https://github.com/user-attachments/assets/4d30e2ff-d7c2-4b1c-9a46-9d5eb4cf76fd)

- 조회된 친구 없음
![image](https://github.com/user-attachments/assets/fe22ead9-ab1a-43c7-93a4-c837e546075d)

## Ref
#30 

Closes #30 


