### PR TITLE
[Posts] 게시물, 댓글 연동

### DIFF
--- a/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
@@ -4,10 +4,18 @@ import com.sns.api.comments.domain.entity.Comments;
 import com.sns.api.posts.domain.entity.Posts;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
+    /**
+     * 
+     * @param post 게시물 entity
+     * @param pageable 생성일 기준 내림차순 정렬이 default
+     * @return
+     */
+    @EntityGraph(attributePaths = "createdBy")
     Page<Comments> findAllByPost(Posts post, Pageable pageable);
 
 }

--- a/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/sns/api/comments/repository/CommentsRepository.java
@@ -10,10 +10,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     /**
+     * 특정 게시물에 속하는 댓글 전체 조회
      * 
      * @param post 게시물 entity
-     * @param pageable 생성일 기준 내림차순 정렬이 default
-     * @return
+     * @param pageable 생성일 기준 내림차순 정렬이 디폴트
+     * @return 댓글 목록
      */
     @EntityGraph(attributePaths = "createdBy")
     Page<Comments> findAllByPost(Posts post, Pageable pageable);

--- a/src/main/java/com/sns/api/posts/controller/PostsController.java
+++ b/src/main/java/com/sns/api/posts/controller/PostsController.java
@@ -5,6 +5,7 @@ import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
 import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
 import com.sns.api.posts.service.PostsService;
 import com.sns.common.component.BaseResponse;
 import com.sns.common.component.Const;
@@ -33,11 +34,11 @@ public class PostsController {
     }
 
     @GetMapping("/{postId}")
-    public BaseResponse<PostResponseDto> getPost(@PathVariable Long postId) {
+    public BaseResponse<PostWithCommentsResponseDto> getPost(@PathVariable Long postId) {
 
-        PostResponseDto post = postsService.getPostById(postId);
+        PostWithCommentsResponseDto postWithComments = postsService.getPostById(postId);
 
-        return BaseResponse.success(post, ResultCode.OK);
+        return BaseResponse.success(postWithComments, ResultCode.OK);
     }
 
     @GetMapping

--- a/src/main/java/com/sns/api/posts/domain/dto/response/PostFlatDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/response/PostFlatDto.java
@@ -1,0 +1,24 @@
+package com.sns.api.posts.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostFlatDto {
+
+    private Long postId;                // 게시물 ID
+    
+    private Long userId;                // 작성자 ID
+    private String username;            // 작성자 이름
+
+    private String content;             // 본문
+    
+    private Long commentCount;         // 댓글 개수
+
+    private LocalDateTime createdAt;    // 생성일
+    private LocalDateTime modifiedAt;   // 수정일
+
+}

--- a/src/main/java/com/sns/api/posts/domain/dto/response/PostResponseDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/response/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.sns.api.posts.domain.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.entity.Posts;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,9 @@ public class PostResponseDto {
 
     private String content;             // 본문
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long commentCount;          // 댓글 개수
+
     private LocalDateTime createdAt;    // 생성일
     private LocalDateTime modifiedAt;   // 수정일
 
@@ -24,8 +28,23 @@ public class PostResponseDto {
                 entity.getId(),
                 UserBaseDto.fromEntity(entity.getCreatedBy()),
                 entity.getContent(),
+                null,
                 entity.getCreatedAt(),
                 entity.getModifiedAt()
+        );
+    }
+
+    public static PostResponseDto fromFlatDto(PostFlatDto dto) {
+        return new PostResponseDto(
+                dto.getPostId(),
+                UserBaseDto.builder()
+                        .userId(dto.getUserId())
+                        .username(dto.getUsername())
+                        .build(),
+                dto.getContent(),
+                dto.getCommentCount(),
+                dto.getCreatedAt(),
+                dto.getModifiedAt()
         );
     }
 

--- a/src/main/java/com/sns/api/posts/domain/dto/response/PostWithCommentsResponseDto.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/response/PostWithCommentsResponseDto.java
@@ -1,0 +1,38 @@
+package com.sns.api.posts.domain.dto.response;
+
+import com.sns.api.comments.domain.dto.response.CommentResponseDto;
+import com.sns.api.comments.domain.entity.Comments;
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.entity.Posts;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostWithCommentsResponseDto {
+
+    private Long postId;                        // 게시물 ID
+    private UserBaseDto createdBy;              // 작성자 정보
+
+    private String content;                     // 본문
+
+    private LocalDateTime createdAt;            // 생성일
+    private LocalDateTime modifiedAt;           // 수정일
+    
+    private Page<CommentResponseDto> commentList;     // 댓글 리스트
+
+    public static PostWithCommentsResponseDto fromEntity(Posts entity, Page<Comments> comments) {
+        return new PostWithCommentsResponseDto(
+                entity.getId(),
+                UserBaseDto.fromEntity(entity.getCreatedBy()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                comments.map(CommentResponseDto::fromEntity)
+        );
+    }
+
+}

--- a/src/main/java/com/sns/api/posts/repository/PostsRepository.java
+++ b/src/main/java/com/sns/api/posts/repository/PostsRepository.java
@@ -1,5 +1,6 @@
 package com.sns.api.posts.repository;
 
+import com.sns.api.posts.domain.dto.response.PostFlatDto;
 import com.sns.api.posts.domain.entity.Posts;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +12,46 @@ import java.time.LocalDateTime;
 
 public interface PostsRepository extends JpaRepository<Posts, Long> {
 
-    @Query("SELECT p FROM Posts p WHERE p.createdAt >= :startDate AND p.createdAt <= :endDate")
-    Page<Posts> findPostsByCreatedAt(@Param("startDate") LocalDateTime startDate,
+    /**
+     * 게시글 전체 조회
+     * 댓글 개수를 서브쿼리를 날려서 카운트
+     *
+     * @param pageable 생성일 기준 내림차순 정렬이 디폴트
+     * @return PostFlatDto DTO 객체에 매핑 후 반환
+     */
+    @Query(value = """
+        SELECT new com.sns.api.posts.domain.dto.response.PostFlatDto(
+            p.id,
+            u.id,
+            u.username,
+            p.content,
+            (SELECT CAST(count(c) as long) FROM Comments c WHERE c.post.id = p.id),
+            p.createdAt,
+            p.modifiedAt
+        )
+        FROM Posts p
+        JOIN p.createdBy u
+    """,
+    countQuery = "SELECT COUNT(p) FROM Posts p")
+    Page<PostFlatDto> findAllWithCommentCount(Pageable pageable);
+
+    // TODO: 위의 쿼리와 중복된다. Querydsl 등을 활용하여 동적으로 쿼리를 사용해보자.
+    @Query(value = """
+        SELECT new com.sns.api.posts.domain.dto.response.PostFlatDto(
+            p.id,
+            u.id,
+            u.username,
+            p.content,
+            (SELECT CAST(count(c) as long) FROM Comments c WHERE c.post.id = p.id),
+            p.createdAt,
+            p.modifiedAt
+        )
+        FROM Posts p
+        JOIN p.createdBy u
+        WHERE p.createdAt >= :startDate AND p.createdAt <= :endDate
+    """,
+    countQuery = "SELECT COUNT(p) FROM Posts p")
+    Page<PostFlatDto> findPostsByCreatedAt(@Param("startDate") LocalDateTime startDate,
                                      @Param("endDate") LocalDateTime endDate,
                                      Pageable pageable);
 

--- a/src/main/java/com/sns/api/posts/service/PostsService.java
+++ b/src/main/java/com/sns/api/posts/service/PostsService.java
@@ -5,6 +5,7 @@ import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
 import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,7 +13,7 @@ public interface PostsService {
 
     PostResponseDto createPost(PostCreateRequestDto createRequestDto);
 
-    PostResponseDto getPostById(Long postId);
+    PostWithCommentsResponseDto getPostById(Long postId);
 
     Page<PostResponseDto> getPosts(PostSearchRequestDto searchRequestDto, Pageable pageable);
 

--- a/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
+++ b/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
@@ -6,6 +6,7 @@ import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
 import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
+import com.sns.api.posts.domain.dto.response.PostFlatDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
 import com.sns.api.posts.domain.entity.Posts;
@@ -84,16 +85,16 @@ public class PostsServiceImpl implements PostsService {
         // 기간별 검색
         // startDate, endDate 모두 null 값이 아니고, startDate <= endDate 이어야 기간별 검색 쿼리를 수행
         if (searchRequestDto.hasValidValue()) {
-            Page<Posts> findPosts = postsRepository.findPostsByCreatedAt(
+            Page<PostFlatDto> findPosts = postsRepository.findPostsByCreatedAt(
                     searchRequestDto.getStartDate(),
                     searchRequestDto.getEndDate(),
                     pageable
             );
-            return findPosts.map(PostResponseDto::fromEntity);
+            return findPosts.map(PostResponseDto::fromFlatDto);
         }
         
         // 일반 검색
-        return postsRepository.findAll(pageable).map(PostResponseDto::fromEntity);
+        return postsRepository.findAllWithCommentCount(pageable).map(PostResponseDto::fromFlatDto);
     }
 
     @Transactional

--- a/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
+++ b/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
@@ -1,10 +1,13 @@
 package com.sns.api.posts.service.impl;
 
+import com.sns.api.comments.domain.entity.Comments;
+import com.sns.api.comments.repository.CommentsRepository;
 import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
 import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
 import com.sns.api.posts.domain.entity.Posts;
 import com.sns.api.posts.repository.PostsRepository;
 import com.sns.api.posts.service.PostsService;
@@ -14,7 +17,9 @@ import com.sns.common.component.ResultCode;
 import com.sns.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +30,9 @@ import java.util.Objects;
 public class PostsServiceImpl implements PostsService {
 
     private final PostsRepository postsRepository;
+
     private final UsersRepository usersRepository;
+    private final CommentsRepository commentsRepository;
 
     @Transactional
     @Override
@@ -40,13 +47,28 @@ public class PostsServiceImpl implements PostsService {
         return PostResponseDto.fromEntity(savedPost);
     }
 
+    /**
+     * 게시물 단건 조회
+     * 게시물에 속한 댓글들도 함께 조회한다.
+     * 댓글은 기본적으로 0 페이지의 데이터를 조회하며, 만약 추가적인 데이터가 필요하다면 GET `/api/posts/{postId}/comments` API 사용
+     * @see com.sns.api.comments.controller.CommentsController#getComments(Long, Pageable)
+     *
+     * @param postId 조회할 게시물 ID
+     * @return 댓글 리스트를 포함한 게시물 상세 정보 DTO
+     */
     @Transactional(readOnly = true)
     @Override
-    public PostResponseDto getPostById(Long postId) {
+    public PostWithCommentsResponseDto getPostById(Long postId) {
 
         Posts post = getPostByIdOrElseThrow(postId);
 
-        return PostResponseDto.fromEntity(post);
+        // 댓글 조회
+        Page<Comments> comments = commentsRepository.findAllByPost(
+                post,
+                PageRequest.of(0, 10, Sort.by("createdBy").descending())
+        );
+
+        return PostWithCommentsResponseDto.fromEntity(post, comments);
     }
 
     /**


### PR DESCRIPTION
## Description
- 게시물 목록 조회 시 댓글 개수 필드 추가
- 게시물 단건 조회 시 댓글 목록과 함께 조회
- N + 1 문제 해결

## Changes
- 게시물 단건 조회
  - EntityGraph를 사용해서 댓글 조회 시 N+1 문제가 발생하는 것을 방지한다.
- 게시물 전체 조회
  - 서브쿼리를 활용해 댓글 개수를 조회한다.

## Ref
- #35 

This closes #35 
