### PR TITLE
[Users] 회원 검색 시 친구 먼저 정렬되는 기능 추가

### DIFF
--- a/src/main/java/com/sns/api/users/controller/UsersController.java
+++ b/src/main/java/com/sns/api/users/controller/UsersController.java
@@ -56,10 +56,12 @@ public class UsersController {
 
     @GetMapping
     public BaseResponse<Page<UserReadResponseDto>> searchUsers(
-            @PageableDefault(size = 5, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            @RequestParam(required = false) String username, @RequestParam(required = false) String email) {
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String username, @RequestParam(required = false) String email,
+            @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto) {
 
-        return BaseResponse.success(usersService.searchUsers(pageable, username, email), ResultCode.OK);
+        return BaseResponse.success(usersService.searchUsers(pageable, username, email, userBaseDto.getUserId()),
+                ResultCode.OK);
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/com/sns/api/users/controller/UsersController.java
+++ b/src/main/java/com/sns/api/users/controller/UsersController.java
@@ -35,12 +35,25 @@ public class UsersController {
 
     private final UsersService usersService;
 
+    /**
+     * 내 정보 조회 API
+     *
+     * @param dto 로그인 유저 정보
+     * @return 내 정보 및 200 OK 응답
+     */
     @GetMapping("/me")
     public BaseResponse<UsersResponseDto> getMyInfo(@SessionAttribute(Const.LOGIN_USER) UserBaseDto dto) {
 
         return BaseResponse.success(usersService.getMyInfo(dto.getUserId()), ResultCode.OK);
     }
 
+    /**
+     * 내 정보 수정 API
+     *
+     * @param userDto 로그인 유저 정보
+     * @param updateDto 수정할 정보
+     * @return 수정된 내 정보 및 200 OK 응답
+     */
     @PutMapping("/me")
     public BaseResponse<UsersResponseDto> updateMyInfo(@SessionAttribute(Const.LOGIN_USER) UserBaseDto userDto,
                                                        @RequestBody @Valid UserUpdateRequestDto updateDto) {
@@ -48,12 +61,27 @@ public class UsersController {
         return BaseResponse.success(usersService.updateMyInfo(userDto.getUserId(), updateDto), ResultCode.OK);
     }
 
+    /**
+     * 회원 정보 조회 API
+     *
+     * @param id 조회할 회원 id
+     * @return 조회된 회원 정보 및 200 OK 응답
+     */
     @GetMapping("/{id}")
     public BaseResponse<UserReadResponseDto> findById(@PathVariable Long id) {
 
         return BaseResponse.success(usersService.findById(id), ResultCode.OK);
     }
 
+    /**
+     * 회원 검색 API
+     *
+     * @param pageable 페이징 정보
+     * @param username 검색할 회원 이름
+     * @param email 검색할 회원 이메일
+     * @param userBaseDto 로그인 유저 정보
+     * @return 검색된 회원 page 및 200 OK 응답
+     */
     @GetMapping
     public BaseResponse<Page<UserReadResponseDto>> searchUsers(
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,

--- a/src/main/java/com/sns/api/users/repository/UsersRepository.java
+++ b/src/main/java/com/sns/api/users/repository/UsersRepository.java
@@ -1,6 +1,7 @@
 package com.sns.api.users.repository;
 
 import com.sns.api.users.domain.entity.Users;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,12 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
     @Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
     Optional<Users> findByEmailIncludeDeleted(@Param("email") String email);
 
-    @Query("SELECT u FROM Users u WHERE (:username IS NULL OR u.username LIKE %:username%) AND (:email IS NULL OR u.email LIKE %:email%)")
-    Page<Users> searchByUsernameAndEmail(Pageable pageable, @Param("username") String username, @Param("email") String email);
+    @Query("""
+            SELECT u FROM Users u 
+            WHERE (:username IS NULL OR u.username LIKE %:username%) 
+             AND (:email IS NULL OR u.email LIKE %:email%)
+            ORDER BY CASE WHEN u.id IN :friendIds THEN 0 ELSE 1 END
+            """)
+    Page<Users> searchByUsernameAndEmail(Pageable pageable, @Param("username") String username,
+                                         @Param("email") String email, @Param("friendIds") Set<Long> friendIds);
 }

--- a/src/main/java/com/sns/api/users/repository/UsersRepository.java
+++ b/src/main/java/com/sns/api/users/repository/UsersRepository.java
@@ -11,11 +11,27 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
+    /**
+     * 이메일을 기준으로 삭제되지 않은 회원 정보를 조회
+     *
+     * @param email 조회할 회원의 이메일
+     * @return 해당 이메일을 가진 회원 정보
+     */
     Optional<Users> findByEmail(String email);
 
     @Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
     Optional<Users> findByEmailIncludeDeleted(@Param("email") String email);
 
+    /**
+     * 회원 이름과 이메일을 기준으로 회원 목록을 검색하고 친구 id 목록에 포함된 회원을 우선 정렬하여 페이징
+     * 검색 조건이 없을 경우 전체 조회
+     *
+     * @param pageable 페이징 정보를 담고 있는 Pageable 객체
+     * @param username 검색할 회원 이름
+     * @param email 검색할 이메일
+     * @param friendIds 친구 id 목록
+     * @return 조회된 회원 목록을 page 형태로 반환
+     */
     @Query("""
             SELECT u FROM Users u 
             WHERE (:username IS NULL OR u.username LIKE %:username%) 

--- a/src/main/java/com/sns/api/users/service/UsersService.java
+++ b/src/main/java/com/sns/api/users/service/UsersService.java
@@ -16,7 +16,7 @@ public interface UsersService {
 
     UserReadResponseDto findById(Long id);
 
-    Page<UserReadResponseDto> searchUsers(Pageable pageable, String username, String email);
+    Page<UserReadResponseDto> searchUsers(Pageable pageable, String username, String email, Long userId);
 
     void deleteMe(Long id, UserDeleteRequestDto requestDto);
 

--- a/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
@@ -14,14 +14,11 @@ import com.sns.common.component.ResultCode;
 import com.sns.common.config.PasswordEncoder;
 import com.sns.common.exception.CustomException;
 import jakarta.transaction.Transactional;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -35,6 +32,12 @@ public class UsersServiceImpl implements UsersService {
 
     private final FriendsRepository friendsRepository;
 
+    /**
+     * 내 정보 조회
+     *
+     * @param id 조회할 본인 id
+     * @return 내 정보를 담은 dto
+     */
     @Override
     public UsersResponseDto getMyInfo(Long id) {
 
@@ -43,6 +46,13 @@ public class UsersServiceImpl implements UsersService {
         return UsersResponseDto.fromEntity(user);
     }
 
+    /**
+     * 내 정보 수정
+     *
+     * @param id 수정할 본인 id
+     * @param dto 수정할 정보
+     * @return 수정한 내 정보를 담은 dto
+     */
     @Override
     @Transactional
     public UsersResponseDto updateMyInfo(Long id, UserUpdateRequestDto dto) {
@@ -88,6 +98,12 @@ public class UsersServiceImpl implements UsersService {
         usersRepository.save(user);
     }
 
+    /**
+     * 회원 정보 조회
+     *
+     * @param id 조회할 회원 id
+     * @return 조회된 회원 정보를 담은 dto
+     */
     @Override
     public UserReadResponseDto findById(Long id) {
 
@@ -96,9 +112,19 @@ public class UsersServiceImpl implements UsersService {
         return UserReadResponseDto.fromEntity(user);
     }
 
+    /**
+     * 회원 검색
+     *
+     * @param pageable 페이징 정보
+     * @param username 검색할 회원 이름
+     * @param email 검색할 회원 이메일
+     * @param userId 로그인한 유저 id
+     * @return 검색된 회원 정보를 담은 dto page
+     */
     @Override
     public Page<UserReadResponseDto> searchUsers(Pageable pageable, String username, String email, Long userId) {
 
+        // 로그인한 유저의 친구 id 목록을 조회
         Set<Long> friendsIds = friendsRepository.findAcceptedFriendsByLoginUserId(userId, Pageable.unpaged()).stream()
                 .map(f -> f.getFromUser().getId().equals(userId) ? f.getToUser().getId() : f.getFromUser().getId())
                 .collect(Collectors.toSet());
@@ -107,6 +133,12 @@ public class UsersServiceImpl implements UsersService {
                 .map(UserReadResponseDto::fromEntity);
     }
 
+    /**
+     * 회원을 조회하고 없으면 예외를 발생시키는 메서드
+     *
+     * @param id 조회할 회원 id
+     * @return 회원이 존재하면 users, 존재하지 않으면 NOT_FOUND
+     */
     private Users findByIdOrElseThrow(Long id) {
 
         return usersRepository.findById(id).orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND));

--- a/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sns.api.users.service.impl;
 
+import com.sns.api.friends.repository.FriendsRepository;
 import com.sns.api.users.domain.dto.UserReadResponseDto;
 import com.sns.api.users.domain.dto.UserUpdateRequestDto;
 import com.sns.api.users.domain.dto.PasswordUpdateDto;
@@ -13,9 +14,14 @@ import com.sns.common.component.ResultCode;
 import com.sns.common.config.PasswordEncoder;
 import com.sns.common.exception.CustomException;
 import jakarta.transaction.Transactional;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +32,8 @@ public class UsersServiceImpl implements UsersService {
     private final UsersRepository usersRepository;
 
     private final PasswordEncoder passwordEncoder;
+
+    private final FriendsRepository friendsRepository;
 
     @Override
     public UsersResponseDto getMyInfo(Long id) {
@@ -89,9 +97,18 @@ public class UsersServiceImpl implements UsersService {
     }
 
     @Override
-    public Page<UserReadResponseDto> searchUsers(Pageable pageable, String username, String email) {
+    public Page<UserReadResponseDto> searchUsers(Pageable pageable, String username, String email, Long userId) {
 
-        return usersRepository.searchByUsernameAndEmail(pageable, username, email).map(UserReadResponseDto::fromEntity);
+        Set<Long> friendsIds = friendsRepository.findAcceptedFriendsByLoginUserId(userId, Pageable.unpaged()).stream()
+                .map(f -> f.getFromUser().getId().equals(userId) ? f.getToUser().getId() : f.getFromUser().getId())
+                .collect(Collectors.toSet());
+
+        Page<Users> usersPage = usersRepository.searchByUsernameAndEmail(pageable, username, email);
+
+        List<UserReadResponseDto> sortedList = usersPage.getContent().stream().map(UserReadResponseDto::fromEntity)
+                .sorted(Comparator.comparing((UserReadResponseDto u) -> !friendsIds.contains(u.getUserId()))).toList();
+
+        return new PageImpl<>(sortedList, pageable, usersPage.getTotalElements());
     }
 
     private Users findByIdOrElseThrow(Long id) {

--- a/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
@@ -103,12 +103,8 @@ public class UsersServiceImpl implements UsersService {
                 .map(f -> f.getFromUser().getId().equals(userId) ? f.getToUser().getId() : f.getFromUser().getId())
                 .collect(Collectors.toSet());
 
-        Page<Users> usersPage = usersRepository.searchByUsernameAndEmail(pageable, username, email);
-
-        List<UserReadResponseDto> sortedList = usersPage.getContent().stream().map(UserReadResponseDto::fromEntity)
-                .sorted(Comparator.comparing((UserReadResponseDto u) -> !friendsIds.contains(u.getUserId()))).toList();
-
-        return new PageImpl<>(sortedList, pageable, usersPage.getTotalElements());
+        return usersRepository.searchByUsernameAndEmail(pageable, username, email, friendsIds)
+                .map(UserReadResponseDto::fromEntity);
     }
 
     private Users findByIdOrElseThrow(Long id) {

--- a/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/sns/api/users/service/impl/UsersServiceImpl.java
@@ -141,6 +141,6 @@ public class UsersServiceImpl implements UsersService {
      */
     private Users findByIdOrElseThrow(Long id) {
 
-        return usersRepository.findById(id).orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND));
+        return usersRepository.findById(id).orElseThrow(() -> new CustomException(ResultCode.NOT_FOUND, "해당 회원이 존재하지 않습니다.: " + id));
     }
 }


### PR DESCRIPTION
## Description
- 회원 검색 시 겸색 결과에서 친구가 먼저 조회되도록 구현
- 검색 키워드가 없으면 친구가 먼저 표시되며 전체 회원 조회가 이루어짐

## Changes
- Users 전반적인 주석 추가
