### PR TITLE
[Friends][Fix]보낸 / 받은 친구 요청의 잘못 적용된 정렬 조건 수정

### DIFF
--- a/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
+++ b/src/main/java/com/sns/api/friends/repository/FriendsRepository.java
@@ -50,7 +50,7 @@ public interface FriendsRepository extends JpaRepository<Friends, Long> {
         select f from Friends f
         where f.toUser.id = :loginUserId
             and f.status = 'PENDING'
-        order by f.toUser.username
+        order by f.fromUser.username
 
     """)
     Page<Friends> findReceivedFriendsByLoginUserId(@Param("loginUserId") Long loginUserId, Pageable pageable);
@@ -68,7 +68,7 @@ public interface FriendsRepository extends JpaRepository<Friends, Long> {
         select f from Friends f
         where f.fromUser.id = :loginUserId
             and f.status = 'PENDING'
-        order by f.fromUser.username
+        order by f.toUser.username
     """)
     Page<Friends> findSentFriendsByLoginUserId(@Param("loginUserId") Long loginUserId, Pageable pageable);
 }


### PR DESCRIPTION
## Description
- 상대방 username 기준으로 조회해야 하지만 로그인한 유저로 기준으로 정렬 되던 것을 수정

## Changes
- FriendsRepository의 findSentFriendsByLoginUserId() 메서드와 findReceivedFriendsByLoginUserId() 메서드의 정렬 조건을 상대방 유저이름으로 변경

## Screenshots
- 보낸 친구 요청 상대방 이름으로 오름차순 정렬 성공
![image](https://github.com/user-attachments/assets/4e5ae51c-a9f7-4971-bd69-5e5b7205c3d9)


- 받은 친구 요청 상대방 이름으로 오름차순 정렬 성공
![image](https://github.com/user-attachments/assets/b29f794d-125e-41fd-8784-f502c56c69d6)


## Ref
#62 
closes #62 
