### PR TITLE
[Setting] 단위 테스트에서 id를 직접 세팅 할 수 있는 엔티티 전용 유틸 클래스 생성

### DIFF
--- a/src/test/java/com/sns/util/TestEntityUtil.java
+++ b/src/test/java/com/sns/util/TestEntityUtil.java
@@ -1,0 +1,22 @@
+package com.sns.util;
+
+import java.lang.reflect.Field;
+
+/**
+ * Test에서만 사용하는 유틸 - 인스턴스 생성 방지하기 위해 abstract class로 작성
+ */
+public abstract class TestEntityUtil {
+
+    /**
+     * Entity ID 생성 전략이 IDENTITY(DB에서 자동 생성) 전략이므로 테스트에서 ID를 강제로 생성하기 위한 util 메서드
+     */
+    public static <T> void setId(T target, Long id) {
+        try {
+            Field idField = target.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(target, id);
+        } catch (Exception e) {
+            throw new RuntimeException("ID 필드 주입 실패");
+        }
+    }
+}


### PR DESCRIPTION
## Description
- 단위 테스트시 Entity에 id를 직접 할당하지 못하는 Entity들이 있는데, 해당 엔티티에 리플렉션을 이용하여 id값을 강제로 삽입할 수 있도록 하는 유틸 클래스를 지정
- 해당 건은 빠르게 merge 될 수 있도록 issue 없이 PR 진행 하였습니다

## Screenshots
- 사용 예시
![image](https://github.com/user-attachments/assets/d80df617-5ea1-4df0-8849-5f06e1b0208d)


