### PR TITLE
[Posts] 내가 좋아요한 게시글 목록 조회 구현

### DIFF
--- a/src/main/java/com/sns/api/posts/controller/LikedPostController.java
+++ b/src/main/java/com/sns/api/posts/controller/LikedPostController.java
@@ -1,0 +1,34 @@
+package com.sns.api.posts.controller;
+
+import com.sns.api.common.domain.dto.UserBaseDto;
+import com.sns.api.posts.domain.dto.response.PostResponseDto;
+import com.sns.api.posts.service.PostsService;
+import com.sns.common.component.BaseResponse;
+import com.sns.common.component.Const;
+import com.sns.common.component.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequestMapping("/api/users/me/likes")
+@RequiredArgsConstructor
+public class LikedPostController {
+
+    private final PostsService postsService;
+
+    @GetMapping
+    public BaseResponse<Page<PostResponseDto>> getMyLikedPosts(
+            @SessionAttribute(Const.LOGIN_USER) UserBaseDto userBaseDto,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        return BaseResponse.success(postsService.getMyLikedPosts(userBaseDto, pageable), ResultCode.OK);
+    }
+}
+

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
@@ -16,4 +16,5 @@ public interface PostQueryRepository {
                                            LocalDateTime endDate,
                                            Pageable pageable);
 
+    Page<PostResponseDto> findMyLikedPosts(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
@@ -141,6 +141,39 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
         return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<PostResponseDto> findMyLikedPosts(Long userId, Pageable pageable) {
+
+        List<PostResponseDto> results = queryFactory
+                .select(new QPostResponseDto(
+                        posts.id,
+                        new QUserBaseDto(
+                                users.id,
+                                users.username
+                        ),
+                        posts.content,
+                        getCommentCountSubQuery(),
+                        getLikesCountSubQuery(),
+                        getIsLikedSubQuery(userId),
+                        posts.createdAt,
+                        posts.modifiedAt
+                ))
+                .from(posts)
+                .join(posts.createdBy, users)
+                .join(likes).on(likes.likeTypeId.eq(posts.id))
+                .where(likes.createdBy.id.eq(userId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(posts.count())
+                .from(posts)
+                .join(likes).on(likes.likeTypeId.eq(posts.id))
+                .where(likes.createdBy.id.eq(userId), likes.likeType.eq(LikeType.POST));
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
 
     // 정렬 조건 동적 생성 (친구 게시물 항상 우선 + 정렬 조건별 분기)
     private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort, Long userId) {

--- a/src/main/java/com/sns/api/posts/service/PostsService.java
+++ b/src/main/java/com/sns/api/posts/service/PostsService.java
@@ -21,4 +21,5 @@ public interface PostsService {
 
     void deletePost(Long postId, UserBaseDto userBaseDto);
 
+    Page<PostResponseDto> getMyLikedPosts(UserBaseDto userBaseDto, Pageable pageable);
 }

--- a/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
+++ b/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
@@ -128,6 +128,12 @@ public class PostsServiceImpl implements PostsService {
         postsRepository.delete(post);
     }
 
+    @Override
+    public Page<PostResponseDto> getMyLikedPosts(UserBaseDto userBaseDto, Pageable pageable) {
+
+        return postsRepository.findMyLikedPosts(userBaseDto.getUserId(), pageable);
+    }
+    
 
     private Users getUserByIdOrElseThrow(Long userId) {
 


### PR DESCRIPTION
## Description
- 로그인한 회원이 좋아요한 게시글 목록을 조회할 수 있는 기능 구현
- 결과는 페이징 처리되어 반환

## Changes
- LikedPostController 추가
- PostsService, impl에 `getMyLikedPost` 추가
- PostQueryRepository, impl에 `findMyLikedPosts` 추가
