### PR TITLE
게시물 조회 성능 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 	// DataFaker: 더미데이터 삽입시 랜덤한 데이터를 뽑아내기 위한 라이브러리
 	implementation 'net.datafaker:datafaker:2.4.2'
+
+	// 쿼리 로깅 라이브러리
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sns/api/posts/controller/PostsController.java
+++ b/src/main/java/com/sns/api/posts/controller/PostsController.java
@@ -2,7 +2,7 @@ package com.sns.api.posts.controller;
 
 import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
-import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
+import com.sns.api.posts.domain.dto.request.PostSearchCondition;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
@@ -53,7 +53,7 @@ public class PostsController {
     /**
      * 게시물 전체 조회 API
      *
-     * @param searchRequestDto  검색 조건 파라미터 (게시물 작성일 범위 등)
+     * @param searchCondition   검색 조건 파라미터 (기간별 검색용 날짜 데이터, 친구 게시물만 조회할지 여부 등)
      * @param pageable          생성일 기준 내림차순이 디폴트
      *                          댓글순(comment), 좋아요순(like), 수정일(modifiedAt) 등 다양한 정렬 조건 사용 가능
      * @param userBaseDto       로그인한 회원 정보
@@ -61,11 +61,11 @@ public class PostsController {
      * @return 성공 시 DTO 및 200 응답
      */
     @GetMapping
-    public BaseResponse<Page<PostResponseDto>> getPosts(@ModelAttribute @Valid PostSearchRequestDto searchRequestDto,
+    public BaseResponse<Page<PostResponseDto>> getPosts(@ModelAttribute @Valid PostSearchCondition searchCondition,
                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                                         @SessionAttribute(name = Const.LOGIN_USER) UserBaseDto userBaseDto) {
 
-        Page<PostResponseDto> posts = postsService.getPosts(searchRequestDto, pageable, userBaseDto);
+        Page<PostResponseDto> posts = postsService.getPosts(searchCondition, pageable, userBaseDto);
 
         return BaseResponse.success(posts, ResultCode.OK);
     }

--- a/src/main/java/com/sns/api/posts/domain/dto/request/PostSearchCondition.java
+++ b/src/main/java/com/sns/api/posts/domain/dto/request/PostSearchCondition.java
@@ -10,7 +10,9 @@ import java.time.format.DateTimeParseException;
 
 @Getter
 @AllArgsConstructor
-public class PostSearchRequestDto {
+public class PostSearchCondition {
+
+    private final Boolean isOnlyFriends;
 
     @DateValid
     private String startDate;

--- a/src/main/java/com/sns/api/posts/domain/entity/Posts.java
+++ b/src/main/java/com/sns/api/posts/domain/entity/Posts.java
@@ -9,7 +9,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
-@Table(name = "posts")
+@Table(name = "posts", indexes = @Index(name = "idx_created_at", columnList = "created_at"))
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
@@ -5,7 +5,6 @@ import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PostQueryRepository {

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepository.java
@@ -1,5 +1,6 @@
 package com.sns.api.posts.repository.query;
 
+import com.sns.api.posts.domain.dto.request.PostSearchCondition;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,8 +13,7 @@ public interface PostQueryRepository {
     Optional<PostResponseDto> findPostWithQuery(Long postId, Long userId);
 
     Page<PostResponseDto> findAllWithQuery(Long userId,
-                                           LocalDateTime startDate,
-                                           LocalDateTime endDate,
+                                           PostSearchCondition searchCondition,
                                            Pageable pageable);
 
 }

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
@@ -125,7 +125,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             countQuery
                     .leftJoin(friends)
                     .on(getFriendCondition(userId))
-                    .where(getWhereCondition(searchCondition, userId));
+                    .where(getWhereCondition(searchCondition));
         } else if (searchCondition.getIsOnlyFriends() == Boolean.TRUE) {    // 친구 게시물만 조회하려는 경우
             query
                     .innerJoin(friends)
@@ -148,19 +148,19 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
         // 쿼리 마무리
         query
-                .where(getWhereCondition(searchCondition, userId))     // 동적 where 조건 적용
+                .where(getWhereCondition(searchCondition))     // 동적 where 조건 적용
                 .orderBy(getOrderSpecifiers(searchCondition, pageable.getSort()))    // 정렬 조건 적용
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
         countQuery
-                .where(getWhereCondition(searchCondition, userId));
+                .where(getWhereCondition(searchCondition));
 
         // 페이징 최적화
         // 필요할 때만 count 쿼리 실행함 (ex. 마지막 페이지면 생략 가능)
         return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
     }
 
-    private BooleanBuilder getWhereCondition(PostSearchCondition searchCondition, Long userId) {
+    private BooleanBuilder getWhereCondition(PostSearchCondition searchCondition) {
 
         // 동적 where 조건 빌더
         // 추후 이를 활용해 게시물 본문 등을 키워드로 검색할 수도 있다.

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.sns.api.friends.domain.entity.FriendsStatus;
 import com.sns.api.friends.domain.entity.QFriends;
 import com.sns.api.likes.domain.entity.LikeType;
 import com.sns.api.likes.domain.entity.QLikes;
+import com.sns.api.posts.domain.dto.request.PostSearchCondition;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import com.sns.api.posts.domain.dto.response.QPostResponseDto;
 import com.sns.api.posts.domain.entity.QPosts;
@@ -26,7 +27,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -82,31 +82,22 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
      * - 클라이언트가 요청한 정렬 조건에 맞춰 데이터 조회
      * - startDate, endDate 데이터가 유효하지 않으면 기간 전체 범위로 검색
      *
-     * @param userId        로그인한 회원 ID
-     * @param startDate     생성일 기간별 검색 조건 (시작일)
-     * @param endDate       생성일 기간별 검색 조건 (종료일)
-     * @param pageable      page, size, 정렬 조건 등을 가지고 있는 페이징 객체
+     * @param userId            로그인한 회원 ID
+     * @param searchCondition   검색 조건
+     * @param pageable          page, size, 정렬 조건 등을 가지고 있는 페이징 객체
      *
      * @return  게시물/작성자 정보, 댓글 개수, 좋아요 개수, 로그인한 회원의 좋아요 여부 등의 데이터를 포함
      */
     @Override
     public Page<PostResponseDto> findAllWithQuery(Long userId,
-                                                  LocalDateTime startDate,
-                                                  LocalDateTime endDate,
+                                                  PostSearchCondition searchCondition,
                                                   Pageable pageable) {
 
-        // 동적 where 조건 빌더
-        // 추후 이를 활용해 게시물 본문 등을 키워드로 검색할 수도 있다.
-        BooleanBuilder builder = new BooleanBuilder();
-
-        // 생성일 기준 기간별 검색
-        if (startDate != null && endDate != null) {
-            builder.and(posts.createdAt.goe(startDate));
-            builder.and(posts.createdAt.loe(endDate));
-        }
+        // count 쿼리 작성 (페이징 total count 용도)
+        JPAQuery<Long> countQuery = queryFactory.select(posts.count()).from(posts);
 
         // 메인 쿼리
-        List<PostResponseDto> results = queryFactory
+        JPAQuery<PostResponseDto> query = queryFactory
                 .select(new QPostResponseDto(
                         posts.id,
                         new QUserBaseDto(
@@ -121,40 +112,83 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                         posts.modifiedAt
                 ))
                 .from(posts)
-                .join(posts.createdBy, users)
-                .leftJoin(friends)
-                    .on(friends.status.eq(FriendsStatus.ACCEPT)
-                            .and(getFriendCondition(userId)))
-                .where(builder)     // 동적 where 조건 적용
-                .orderBy(getOrderSpecifiers(pageable.getSort(), userId))    // 정렬 조건 적용
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .join(posts.createdBy, users);
 
-        // count 쿼리 작성 (페이징 total count 용도)
-        JPAQuery<Long> countQuery = queryFactory
-                .select(posts.count())
-                .from(posts)
-                .where(builder);
+        // 전체 게시물을 조회할지, 친구 게시물만 조회할지, 그 외 사람들의 게시물만 조회할지에 따라 (isOnlyFriends)
+        // 메인 쿼리와 카운트 쿼리의 JOIN 구문이 분기 처리된다.
+        // 차례대로 LEFT JOIN, INNER JOIN, LEFT OUT JOIN
+        if (searchCondition.getIsOnlyFriends() == null) {                   // 전체 게시물 조회
+            query
+                    .leftJoin(friends)
+                    .on(getFriendCondition(userId));
+
+            countQuery
+                    .leftJoin(friends)
+                    .on(getFriendCondition(userId))
+                    .where(getWhereCondition(searchCondition, userId));
+        } else if (searchCondition.getIsOnlyFriends() == Boolean.TRUE) {    // 친구 게시물만 조회하려는 경우
+            query
+                    .innerJoin(friends)
+                    .on(getFriendCondition(userId));
+
+            countQuery
+                    .innerJoin(friends)
+                    .on(getFriendCondition(userId));
+        } else {                                                            // 그 외 사람들의 게시물만 조회하려는 경우
+            query
+                    .leftJoin(friends)
+                    .on(getFriendCondition(userId))
+                    .where(friends.id.isNull());
+
+            countQuery
+                    .leftJoin(friends)
+                    .on(getFriendCondition(userId))
+                    .where(friends.id.isNull());
+        }
+
+        // 쿼리 마무리
+        query
+                .where(getWhereCondition(searchCondition, userId))     // 동적 where 조건 적용
+                .orderBy(getOrderSpecifiers(searchCondition, pageable.getSort()))    // 정렬 조건 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+        countQuery
+                .where(getWhereCondition(searchCondition, userId));
 
         // 페이징 최적화
         // 필요할 때만 count 쿼리 실행함 (ex. 마지막 페이지면 생략 가능)
-        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
     }
 
+    private BooleanBuilder getWhereCondition(PostSearchCondition searchCondition, Long userId) {
+
+        // 동적 where 조건 빌더
+        // 추후 이를 활용해 게시물 본문 등을 키워드로 검색할 수도 있다.
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 생성일 기준 기간별 검색
+        if (searchCondition.hasValidValue()) {
+            builder.and(posts.createdAt.goe(searchCondition.getStartDate()));
+            builder.and(posts.createdAt.loe(searchCondition.getEndDate()));
+        }
+
+        return builder;
+    }
 
     // 정렬 조건 동적 생성 (친구 게시물 항상 우선 + 정렬 조건별 분기)
-    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort, Long userId) {
+    private OrderSpecifier<?>[] getOrderSpecifiers(PostSearchCondition searchCondition, Sort sort) {
 
         List<OrderSpecifier<?>> orders = new ArrayList<>();
 
         // 1. 친구 게시물 우선 정렬
-        orders.add(
-                new CaseBuilder()
-                        .when(friends.id.isNotNull()).then(0)
-                        .otherwise(1)
-                        .asc()
-        );
+        if (searchCondition.getIsOnlyFriends() == null) {
+            orders.add(
+                    new CaseBuilder()
+                            .when(friends.id.isNotNull()).then(0)
+                            .otherwise(1)
+                            .asc()
+            );
+        }
 
         // 2. 사용자가 요청한 정렬 조건 적용
         for (Sort.Order order : sort) {

--- a/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/sns/api/posts/repository/query/PostQueryRepositoryImpl.java
@@ -5,8 +5,6 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.DateTimeExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -124,6 +122,9 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 ))
                 .from(posts)
                 .join(posts.createdBy, users)
+                .leftJoin(friends)
+                    .on(friends.status.eq(FriendsStatus.ACCEPT)
+                            .and(getFriendCondition(userId)))
                 .where(builder)     // 동적 where 조건 적용
                 .orderBy(getOrderSpecifiers(pageable.getSort(), userId))    // 정렬 조건 적용
                 .offset(pageable.getOffset())
@@ -147,19 +148,15 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
         List<OrderSpecifier<?>> orders = new ArrayList<>();
 
-        // 1. 친구 우선 정렬 (CASE WHEN THEN 0 ELSE 1 ASC)
-        orders.add(getFriendPriority(userId).asc());
-        // 2. 친구라면 createdAt 기준 최신순 정렬
+        // 1. 친구 게시물 우선 정렬
         orders.add(
-                new OrderSpecifier<>(
-                        Order.DESC,
-                        new CaseBuilder()
-                                .when(getFriendCondition(userId)).then(posts.createdAt)
-                                .otherwise((DateTimeExpression<LocalDateTime>) null)
-                )
+                new CaseBuilder()
+                        .when(friends.id.isNotNull()).then(0)
+                        .otherwise(1)
+                        .asc()
         );
 
-        // 3. 사용자가 요청한 정렬 조건 적용
+        // 2. 사용자가 요청한 정렬 조건 적용
         for (Sort.Order order : sort) {
             Order direction = order.isAscending() ? Order.ASC : Order.DESC;     // 정렬 방향
 
@@ -177,29 +174,14 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
         return orders.toArray(new OrderSpecifier[0]);
     }
 
-    // 친구 여부를 기반으로 CASE WHEN 우선순위 표현식 설정
-    // 이 값을 order by 에서 사용하면 친구가 게시물이 항상 상단에 보임
-    private NumberExpression<Integer> getFriendPriority(Long userId) {
-
-        return new CaseBuilder()
-                .when(getFriendCondition(userId)).then(0)
-                .otherwise(1);
-    }
-
     // 친구 여부 서브쿼리 (로그인한 회원과 게시물 작성자가 친구(ACCEPT)인지 확인)
     private BooleanExpression getFriendCondition(Long userId) {
 
-        return JPAExpressions
-                .selectOne()
-                .from(friends)
-                .where(
-                        friends.status.eq(FriendsStatus.ACCEPT)
-                                .and(
-                                        friends.fromUser.id.eq(userId).and(friends.toUser.id.eq(posts.createdBy.id))
-                                                .or(friends.toUser.id.eq(userId).and(friends.fromUser.id.eq(posts.createdBy.id)))
-                                )
-                )
-                .exists();
+        return friends.status.eq(FriendsStatus.ACCEPT)
+                .and(
+                        friends.fromUser.id.eq(userId).and(friends.toUser.id.eq(posts.createdBy.id))
+                                .or(friends.toUser.id.eq(userId).and(friends.fromUser.id.eq(posts.createdBy.id)))
+                );
     }
 
     // 댓글 개수 서브 쿼리

--- a/src/main/java/com/sns/api/posts/service/PostsService.java
+++ b/src/main/java/com/sns/api/posts/service/PostsService.java
@@ -2,7 +2,7 @@ package com.sns.api.posts.service;
 
 import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
-import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
+import com.sns.api.posts.domain.dto.request.PostSearchCondition;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
@@ -15,7 +15,7 @@ public interface PostsService {
 
     PostWithCommentsResponseDto getPostById(Long postId, UserBaseDto userBaseDto);
 
-    Page<PostResponseDto> getPosts(PostSearchRequestDto searchRequestDto, Pageable pageable, UserBaseDto userBaseDto);
+    Page<PostResponseDto> getPosts(PostSearchCondition searchRequestDto, Pageable pageable, UserBaseDto userBaseDto);
 
     PostResponseDto updatePost(Long postId, PostUpdateRequestDto updateRequestDto, UserBaseDto userBaseDto);
 

--- a/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
+++ b/src/main/java/com/sns/api/posts/service/impl/PostsServiceImpl.java
@@ -4,7 +4,7 @@ import com.sns.api.comments.domain.dto.response.CommentResponseDto;
 import com.sns.api.comments.repository.CommentsRepository;
 import com.sns.api.common.domain.dto.UserBaseDto;
 import com.sns.api.posts.domain.dto.request.PostCreateRequestDto;
-import com.sns.api.posts.domain.dto.request.PostSearchRequestDto;
+import com.sns.api.posts.domain.dto.request.PostSearchCondition;
 import com.sns.api.posts.domain.dto.request.PostUpdateRequestDto;
 import com.sns.api.posts.domain.dto.response.PostResponseDto;
 import com.sns.api.posts.domain.dto.response.PostWithCommentsResponseDto;
@@ -22,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Service
@@ -80,7 +79,7 @@ public class PostsServiceImpl implements PostsService {
      * - 검색 데이터를 활용하여 게시물 조회
      * - 페이징 정보에 포함되어 있는 정렬 기준으로 데이터 조회 (기본은 생성일자 기준 내림차순)
      * 
-     * @param searchRequestDto  검색 데이터
+     * @param searchCondition   검색 데이터
      * @param pageable          페이징 정보
      * @param userBaseDto       로그인한 회원 정보
      *
@@ -88,18 +87,9 @@ public class PostsServiceImpl implements PostsService {
      */
     @Transactional(readOnly = true)
     @Override
-    public Page<PostResponseDto> getPosts(PostSearchRequestDto searchRequestDto, Pageable pageable, UserBaseDto userBaseDto) {
+    public Page<PostResponseDto> getPosts(PostSearchCondition searchCondition, Pageable pageable, UserBaseDto userBaseDto) {
 
-        LocalDateTime startDate = null;
-        LocalDateTime endDate = null;
-
-        // startDate, endDate 모두 null 값이 아니고, startDate <= endDate 이면 값 할당
-        if (searchRequestDto.hasValidValue()) {
-            startDate = searchRequestDto.getStartDate();
-            endDate = searchRequestDto.getEndDate();
-        }
-
-        return postsRepository.findAllWithQuery(userBaseDto.getUserId(), startDate, endDate, pageable);
+        return postsRepository.findAllWithQuery(userBaseDto.getUserId(), searchCondition, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/sns/common/aop/LoggingAspect.java
+++ b/src/main/java/com/sns/common/aop/LoggingAspect.java
@@ -1,0 +1,24 @@
+package com.sns.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class LoggingAspect {
+
+    // 게시물 조회 API 응답 시간 로깅
+    @Around("@annotation(org.springframework.web.bind.annotation.GetMapping)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object proceed = joinPoint.proceed();
+        long end = System.currentTimeMillis();
+
+        log.info("API: {} 실행 시간: {} ms", joinPoint.getSignature(), (end - start));
+        return proceed;
+    }
+}

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,4 @@
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=took %(executionTime) ms | %(sql)
+excludecategories=info,debug,result,resultset


### PR DESCRIPTION
## Description
- 게시물 조회 API의 성능을 최적화했다.
  - 인덱싱 적용, 서브쿼리 -> JOIN으로 대체
  - 게시물의 `created_at` 칼럼을 인덱스로 등록하고, 서브쿼리를 JOIN으로 대체 후 **약 3배 빨라짐** (데이터 10,000개 기준)
  - 추가적인 테스트 필요
- 성능 최적화의 다른 방안 제시 : API 분리
  - 친구 게시물 조회 API와 그 외의 사람들이 작성한 게시물 조회 API로 분리

## Changes
- 쿼리 파라미터로 `isOnlyFriends` 추가
  - `isOnlyFriends` : null -> 전체 게시물 조회 (친구 게시물 우선 조회)
  - `isOnlyFriends` : true -> 친구 게시물만 조회
  - `isOnlyFriends` : false-> 그 외 사람들이 작성한 게시물만 조회

## Screenshots
![image](https://github.com/user-attachments/assets/e7f7a883-7529-4536-8503-bd23783c3e93)

## Ref
- #42 
- #54 

This closes #60 
